### PR TITLE
compare-db: ignore alembic env variable

### DIFF
--- a/compare-db/compare-db-migrations
+++ b/compare-db/compare-db-migrations
@@ -32,6 +32,8 @@ CWD_PATH = os.path.abspath(os.path.dirname(__file__))
 config = ConfigParser()
 config.read(os.path.join(CWD_PATH, 'defaults.ini'))
 
+del os.environ['ALEMBIC_DB_URI']
+
 
 def argparser():
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
reason: the alembic DB URI is already configurable through config file.
Some developers may have the ALEMBIC_DB_URI env variable set for their
pet machine, but we dont want to honor this setting in this case