### PR TITLE
compare-db: remove manually call logs table

### DIFF
--- a/compare-db/compare-db-migrations
+++ b/compare-db/compare-db-migrations
@@ -8,7 +8,7 @@ import sh
 import sqlalchemy as sa
 import sqlalchemy_utils
 import sys
-import xivo_dao.alchemy.all
+import xivo_dao.alchemy.all  # noqa
 
 from configparser import ConfigParser
 
@@ -142,6 +142,27 @@ def run_alembic_migrations(postgresql_uri):
     os.environ['XIVO_UUID'] = '99999999-9999-9999-9999-999999999999'
     alembic_command.stamp(alembic_cfg, 'base')
     alembic_command.upgrade(alembic_cfg, 'head')
+    manually_migrate_call_logd_db(postgresql_uri)
+
+
+def manually_migrate_call_logd_db(postgresql_uri):
+    run_psql_cmd(postgresql_uri, 'DROP TABLE call_log, call_log_participant;')
+    run_psql_cmd(postgresql_uri, 'DROP TYPE call_log_participant_role;')
+
+
+def run_psql_cmd(postgresql_uri, command):
+    error_buffer = io.StringIO()
+    sh.psql(
+        '-qX',
+        d=postgresql_uri,
+        c=command,
+        _err=error_buffer,
+        _env={'PGOPTIONS': '--client-min-messages=warning'},  # prevents NOTICE:
+    )
+    errors = error_buffer.getvalue()
+    if errors:
+        logger.warning("errors while executing %s: %s", command, errors)
+        sys.exit(2)
 
 
 def build_alembic_config(postgresql_uri):

--- a/compare-db/compare-db-migrations
+++ b/compare-db/compare-db-migrations
@@ -145,6 +145,8 @@ def run_alembic_migrations(postgresql_uri):
     manually_migrate_call_logd_db(postgresql_uri)
 
 
+# TODO: buster-bullseye migration: ensure those tables are dropped by alembic
+# then remove this function
 def manually_migrate_call_logd_db(postgresql_uri):
     run_psql_cmd(postgresql_uri, 'DROP TABLE call_log, call_log_participant;')
     run_psql_cmd(postgresql_uri, 'DROP TYPE call_log_participant_role;')


### PR DESCRIPTION
reason: these tables are not removed by alembic, but by an external
script