### PR TITLE
use docker-compose from binary instead of python

### DIFF
--- a/compare-db/README.md
+++ b/compare-db/README.md
@@ -3,7 +3,9 @@
 ## Prerequisites
 
 ```sh
-apt-get install docker-engine
+apt-get install docker-ce
+curl -SL https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose
+chmod +x ~/.docker/cli-plugins/docker-compose
 pip install -r requirements.txt
 ```
 

--- a/compare-db/requirements.txt
+++ b/compare-db/requirements.txt
@@ -1,7 +1,6 @@
 git+https://github.com/wazo-platform/xivo-dao
 git+https://github.com/wazo-platform/xivo-lib-python  # from xivo-dao
 alembic==1.0.0
-docker-compose
 migra[pg]
 packaging  # missing from sqlbag -> from migra
 pytz==2019.1


### PR DESCRIPTION
why: to have the latest docker-compose