### PR TITLE
compare-db: add missing pyyaml dependency

### DIFF
--- a/compare-db/requirements.txt
+++ b/compare-db/requirements.txt
@@ -4,7 +4,8 @@ alembic==1.0.0
 migra[pg]
 packaging  # missing from sqlbag -> from migra
 pytz==2019.1
+pyyaml
 sh
-sqlalchemy==1.2.18
 sqlalchemy-utils==0.32.21
+sqlalchemy==1.2.18
 unidecode==1.0.23  # from alembic scripts


### PR DESCRIPTION
why: was provided by docker-compose v1