### PR TITLE
compare-db: updated README.md

### DIFF
--- a/compare-db/README.md
+++ b/compare-db/README.md
@@ -22,11 +22,103 @@ pip install -r requirements.txt
     docker compose port postgresql-installed 5432
     ```
 
-3. Copy `defaults.ini` to `local.ini` and edit it to set the correct values. If you
-   used the provided `docker-compose.yml`, you only need to change the port numbers.
+3. Copy `defaults.ini` to `local.ini` and edit it to set the correct
+   values. If you used the provided `docker-compose.yml`, you only need to
+   change the port numbers.
 
 4. Run the diff tool
 
     ```sh
     python compare-db-migrations.py --config local.ini
     ```
+
+## Updating migration-base-schema.sql
+
+When cleaning up the alembic revisions in xivo-manage-db, the base schema
+needs to be updated accordingly to match the new base revision(the
+revisions are applied on top of migration-base-schema.sql, which should
+match the baseline schema expected by the alembic revisions).
+
+To produce that baseline, the xivo-manage-db Dockerfile can be used.
+Assuming the new baseline release is 25.14:
+
+1. In the xivo-manage-db repository;
+   checkout the git tag of the release corresponding to the new baseline
+   revision;
+
+   ```sh
+   # in $LOCAL_GIT_REPOS/xivo-manage-db
+   git checkout tags/wazo-25.14
+   ```
+
+2. Update the `requirements.txt` file to use the matching version of wazo
+   dependencies;
+
+    ```sh
+    sed -i 's/master\.zip/refs\/tags\/wazo-25.14\.zip/' requirements.txt
+    ```
+
+3. Build the database image;
+   first build `wazoplatform/wazo-base-db` image from
+   `contribs/docker/wazo-base-db/Dockerfile`;
+   then build the image for a fully initialized database using
+   `Dockerfile`:
+
+   ```sh
+   # in $LOCAL_GIT_REPOS/xivo-manage-db
+   docker build --no-cache -t wazoplatform/wazo-base-db:latest \
+     -f contribs/docker/wazo-base-db/Dockerfile \
+     contribs/docker/wazo-base-db
+   docker build --no-cache -f Dockerfile -t xivo-manage-db:wazo-25.14 .
+   ```
+
+4. Deploy the container image:
+
+   ```sh
+   docker run -d --name xivo-manage-db-25.14 xivo-manage-db:wazo-25.14
+   ```
+
+5. Use pg_dump to dump the baseline schema as a sql file:
+
+   ```sh
+   docker exec -it xivo-manage-db-25.14 \
+   pg_dump -U postgres -d asterisk \
+   --exclude-table=alembic_version \
+   --insert \
+   > baseline-25.14.sql
+   ```
+
+6. Make sure the baseline dump uses unix instead of DOS line endings
+   (i.e. no carriage return characters):
+
+    ```sh
+    dos2unix baseline-25.14.sql
+    ```
+
+    or
+
+    ```sh
+    sed -i 's/\r$//' baseline-25.14.sql
+    ```
+
+7. Copy the generated baseline schema dump to the wazo-tools/compare-db
+   repository as the new migration-base-schema.sql, verify and commit the
+   changes:
+
+   ```sh
+   # in $LOCAL_GIT_REPOS/wazo-tools/compare-db
+   cp $LOCAL_GIT_REPOS/xivo-manage-db/baseline-25.14.sql migration-base-schema.sql
+   git diff migration-base-schema.sql
+   git commit -m "compare-db: raw baseline schema dump for wazo-25.14"
+   ```
+
+8. Run the compare-db-migrations.py tool(see [Usage](#usage))
+9. Investigate each reported mismatches;
+    common issues are changes in normalized representation of
+    constraints;
+   The migration-base-schema.sql file may need to be manually updated to
+   address some mismatches;
+   commit each fix;
+10. When the compare-db-migrations.py tool reports no differences, a PR
+    can be created, and a xivo-manage-db PR can use that PR as a
+    `Depends-on` to validate the CI job.

--- a/compare-db/README.md
+++ b/compare-db/README.md
@@ -35,7 +35,7 @@ pip install -r requirements.txt
 ## Updating migration-base-schema.sql
 
 When cleaning up the alembic revisions in xivo-manage-db, the base schema
-needs to be updated accordingly to match the new base revision(the
+needs to be updated accordingly to match the new base revision (the
 revisions are applied on top of migration-base-schema.sql, which should
 match the baseline schema expected by the alembic revisions).
 
@@ -47,7 +47,7 @@ Assuming the new baseline release is 25.14:
    revision;
 
    ```sh
-   # in $LOCAL_GIT_REPOS/xivo-manage-db
+   cd $LOCAL_GIT_REPOS/xivo-manage-db
    git checkout tags/wazo-25.14
    ```
 
@@ -55,7 +55,7 @@ Assuming the new baseline release is 25.14:
    dependencies;
 
     ```sh
-    sed -i 's/master\.zip/refs\/tags\/wazo-25.14\.zip/' requirements.txt
+    sed -i 's/master\.zip/wazo-25.14\.zip/' requirements.txt
     ```
 
 3. Build the database image;
@@ -65,7 +65,6 @@ Assuming the new baseline release is 25.14:
    `Dockerfile`:
 
    ```sh
-   # in $LOCAL_GIT_REPOS/xivo-manage-db
    docker build --no-cache -t wazoplatform/wazo-base-db:latest \
      -f contribs/docker/wazo-base-db/Dockerfile \
      contribs/docker/wazo-base-db
@@ -106,7 +105,7 @@ Assuming the new baseline release is 25.14:
    changes:
 
    ```sh
-   # in $LOCAL_GIT_REPOS/wazo-tools/compare-db
+   cd $LOCAL_GIT_REPOS/wazo-tools/compare-db
    cp $LOCAL_GIT_REPOS/xivo-manage-db/baseline-25.14.sql migration-base-schema.sql
    git diff migration-base-schema.sql
    git commit -m "compare-db: raw baseline schema dump for wazo-25.14"


### PR DESCRIPTION
with instructions for updating the migration-base-schema.sql

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands README with step-by-step workflow to generate, normalize, and integrate a new baseline schema using xivo-manage-db and pg_dump.
> 
> - **Docs (README)**:
>   - **New section: `Updating migration-base-schema.sql`**
>     - Outline workflow to produce a new baseline from `xivo-manage-db`:
>       - Checkout release tag (e.g., `wazo-25.14`) and update `requirements.txt`.
>       - Build `wazoplatform/wazo-base-db` and the full DB image; run container.
>       - Dump baseline schema via `pg_dump` excluding `alembic_version` and using `--insert`.
>       - Convert line endings to Unix; copy dump to `compare-db/migration-base-schema.sql` and commit.
>       - Run `compare-db-migrations.py`, address mismatches, and open PR (with `Depends-on` for validation).
>   - Minor wording/line-wrapping tweak in setup step for copying `defaults.ini` to `local.ini`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f4d5e88bf9523d9caa6fadccb176540f19ed24a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->