### PR TITLE
repo-check: use setuptools

### DIFF
--- a/repo-check/setup.py
+++ b/repo-check/setup.py
@@ -3,7 +3,7 @@
 import fnmatch
 import os
 
-from distutils.core import setup
+from setuptools import setup
 
 
 def is_package(path):
@@ -23,9 +23,7 @@ setup(
     author_email='dev@avencall.com',
     url='https://github.com/wazo-platform/wazo-tools',
     packages=packages,
-    scripts=['bin/check_local_xivo_repositories',
-             'bin/check_unmerged_branches'],
+    scripts=['bin/check_local_xivo_repositories', 'bin/check_unmerged_branches'],
     license='GPLv3',
     long_description=open('README.md').read(),
-
 )


### PR DESCRIPTION
instead of distutils
why: distutils deprecated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `setup.py` from `distutils` to `setuptools` and minor script list formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab7686954fc112a31a5ddb96c3b085be032865f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->