### PR TITLE
WP-2120-remove-pkg-resources

### DIFF
--- a/openapi-synthesize/openapi_synthesize.py
+++ b/openapi-synthesize/openapi_synthesize.py
@@ -5,7 +5,7 @@ import yaml
 
 from xivo.chain_map import ChainMap
 from xivo.rest_api_helpers import load_all_api_specs
-from pkg_resources import iter_entry_points
+from importlib.metadata import entry_points
 
 def main():
     assert len(sys.argv) >= 2
@@ -13,8 +13,8 @@ def main():
     host = sys.argv[2] if len(sys.argv) >= 3 else None
     prefix = sys.argv[3] if len(sys.argv) >= 4 else None
 
-    for entrypoint in iter_entry_points(http_plugins_package):
-        print(f'Entry point: {entrypoint.module_name}', file=sys.stderr)
+    for entrypoint in entry_points(group=http_plugins_package):
+        print(f'Entry point: {entrypoint.value}', file=sys.stderr)
 
     api_specs = []
     for api_spec in load_all_api_specs(http_plugins_package, 'api.yml'):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to plugin discovery; main risk is differing entry point resolution behavior across Python/setuptools versions.
> 
> **Overview**
> Replaces `pkg_resources.iter_entry_points` usage in `openapi_synthesize.py` with `importlib.metadata.entry_points(group=...)` to discover HTTP plugin entry points, and updates the debug logging to print `entrypoint.value`.
> 
> This removes the runtime dependency on `pkg_resources` for this script while keeping OpenAPI spec aggregation behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d06e0080fc1f5a9a492afce060e28eb9fe12080. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->