### PR TITLE
WP-2120 Fix compare-db with old libraries

### DIFF
--- a/compare-db/requirements.txt
+++ b/compare-db/requirements.txt
@@ -3,6 +3,7 @@ https://github.com/wazo-platform/xivo-lib-python/archive/master.zip # from xivo-
 alembic==1.8.1
 migra[pg]
 pyyaml==6.0
+setuptools<82.0.0  # schemainspect (from migra) need pkg_resources
 sh
 sqlalchemy-utils==0.38.2
 sqlalchemy==1.4.46

--- a/compare-db/tox.ini
+++ b/compare-db/tox.ini
@@ -1,19 +1,12 @@
-# Tox (http://tox.testrun.org/) is a tool for running tests
-# in multiple virtualenvs. This configuration file will run the
-# test suite on all supported python versions. To use it, "pip install tox"
-# and then run "tox" from this directory.
-
 [tox]
 envlist = compare-db
 
 [testenv]
-skip_install = true
 basepython = python3.11
+skip_install = true
 deps =
   -rrequirements.txt
 
 [testenv:compare-db]
 commands =
-    sh -c 'python compare-db-migrations.py --config local.ini'
-allowlist_externals =
-    sh
+    python compare-db-migrations.py --config local.ini


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency pin and tox config cleanup; low blast radius beyond CI/compare-db tooling, with main risk being version conflicts from the setuptools cap.
> 
> **Overview**
> Pins `setuptools<82.0.0` in `compare-db/requirements.txt` to restore `pkg_resources` support required by `schemainspect` (via `migra`).
> 
> Simplifies `compare-db/tox.ini` by removing the `sh -c` wrapper/`allowlist_externals` and running `compare-db-migrations.py` directly, with `skip_install` set under `[testenv]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2570112dde8be52763c909f7ed34bb9aad2ef54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->