### PR TITLE
sanitize coredump

### DIFF
--- a/sanitize-coredump/README.md
+++ b/sanitize-coredump/README.md
@@ -39,3 +39,15 @@ logic to the coredump at hand, then run it.
 `instance-1-logs/instance-1-asterisk-logs/full` log).
 
 Requires Python 3 only (standard library).
+
+## Tests
+
+`test_sanitize_coredump.py` asserts that every redaction pattern actually fires
+on representative input — for a sanitizer a silent non-firing rule is a leak.
+Run with `pytest` from this directory.
+
+## Generalizing beyond this incident
+
+The reusable core here is the line sanitizer. Turning it into a general-purpose
+tool (config-driven customer literals, per-country phone handling, consistent
+pseudonymization, a CLI) is designed in [`GENERALIZATION-PLAN.md`](./GENERALIZATION-PLAN.md).

--- a/sanitize-coredump/README.md
+++ b/sanitize-coredump/README.md
@@ -63,8 +63,8 @@ Global options: `--config FILE`, `--mapping-out FILE`, `--structural-only`,
 
 - `literals` / `domains` — strings redacted everywhere (consistent tokens).
 - `headers` — the value of these PJSIP headers (in gdb arg dumps) is redacted.
-- `phone_country` — opt into a per-country national-number pattern (currently
-  `FR`). National numbers are otherwise not caught; see design notes below.
+- `phone_country` — opt into a per-country national-number pattern (`FR`,
+  `UK`). National numbers are otherwise not caught; see design notes below.
 - `patterns` — raw regex→replacement escape hatch, applied last.
 
 ## Tests
@@ -87,6 +87,12 @@ handling. Run with `pytest` from this directory.
   phone-number / numeric-id space is trivially brute-forced and a leaked salt
   would de-anonymize everything. The reverse map stays out of published output
   by construction (only `--mapping-out`).
+- **Robust to real coredump data**: non-UTF-8 bytes are replaced rather than
+  crashing the run; configured `domains` also match gdb-truncated fragments
+  (`instance1.voip3.bo"...`); UUID-shaped ids are matched with a loose tail so
+  non-standard/truncated trunk UUIDs are caught. Verified against a real
+  coredump: brand, hostnames, trunk UUIDs, E.164/national phones and public
+  IPs all redacted (RFC 5737 `192.0.2.0/24` documentation IPs are kept).
 
 The earlier incident-specific report builder (the 20XX-XX-XX customer deadlock
 narrative, frame selection, `res_freeze_check` marker) was intentionally

--- a/sanitize-coredump/README.md
+++ b/sanitize-coredump/README.md
@@ -1,53 +1,93 @@
 # sanitize-coredump
 
-Extract and anonymize relevant Asterisk coredump snippets so they can be shared
-in a public/upstream bug report without leaking customer-identifying data
-(phone numbers, public IPs, hostnames, endpoint/trunk names, tenant UUIDs, ...).
+Sanitize Asterisk coredump / log excerpts so they can be shared in a
+public/upstream bug report without leaking customer-identifying data (phone
+numbers, public IPs, hostnames, endpoint/trunk names, tenant ids, UUIDs, ...).
 
-It reads [`ast_coredumper`](https://github.com/asterisk/asterisk/blob/master/contrib/scripts/ast_coredumper)
-output (`*-brief.txt`, `*-info.txt`) together with the Asterisk `full` log,
-redacts sensitive tokens line-by-line, and writes:
+It works on [`ast_coredumper`](https://github.com/asterisk/asterisk/blob/master/contrib/scripts/ast_coredumper)
+output (`*-brief.txt`, `*-info.txt`) and Asterisk logs.
 
-- `sanitized-coredump-excerpts.md` — a curated report (deadlock threads,
-  endpoint config evidence, log around the crash, system-state summary)
-- `sanitized-info.txt` — the full `info.txt` with the same redaction applied
+## How it redacts
 
-## Status: incident-specific template
+Two layers:
 
-This script was written for a specific incident (the 20XX-XX-XX customer upgrade
-deadlock) and is **not** a general-purpose tool. Several things are hardcoded
-and must be adapted before reuse:
+- a **built-in structural ruleset** for generic Asterisk/Wazo identifiers and
+  PII (endpoints, channels, MWI subscriptions, tenant/group ids, UUIDs, SIP
+  contacts, E.164 phone numbers, public IPs, ...) — always on;
+- **caller-supplied literals** from `--config` (brand names, vanity domains,
+  tenant slugs, custom SIP headers). These cannot be inferred from shape alone,
+  so without a config they are **not** redacted — the tool warns loudly on
+  stderr when run without one (pass `--structural-only` to acknowledge).
 
-- `prefix` — the `core-asterisk-<timestamp>` filename prefix (in `main()`)
-- the thread LWPs of interest (`834925`, `816915`)
-- the crash marker used to locate the log excerpt (`res_freeze_check ...
-  failed to acquire`)
-- customer-specific redaction patterns (`customer_trunk_*`,
-  `instance*.voip*.customer.com`)
-
-Keep it as a starting point: copy it, adjust the patterns and the extraction
-logic to the coredump at hand, then run it.
+Sensitive values are replaced with stable counter-based tokens (`ENDPOINT_1`,
+`UUID_2`, ...) rather than blanked out, so correlation survives sanitization:
+the same endpoint keeps the same token across threads. The reverse
+token→value map (the de-anonymization key) is written **only** to
+`--mapping-out`, never to the sanitized output — keep it private.
 
 ## Usage
 
 ```sh
-./sanitize-coredump.py [DIR]
+# sanitize a file or stdin (stream filter)
+./sanitize-coredump.py --config customer.json filter core-info.txt > clean-info.txt
+cat core-brief.txt | ./sanitize-coredump.py --structural-only filter
+
+# extract & sanitize specific thread backtraces by LWP
+./sanitize-coredump.py --config customer.json thread core-brief.txt --lwp 834925 --lwp 816915
+
+# extract & sanitize log lines around a marker
+./sanitize-coredump.py --config customer.json log full \
+    --marker 'res_freeze_check.*failed to acquire' --before 5 --after 5
+
+# sanitized system-state summary from info.txt
+./sanitize-coredump.py --config customer.json summary core-info.txt
+
+# keep the de-anonymization key for your own later reference
+./sanitize-coredump.py --config customer.json --mapping-out key.json filter core-info.txt
 ```
 
-`DIR` defaults to the current directory and must contain the
-`ast_coredumper` output files (and optionally the
-`instance-1-logs/instance-1-asterisk-logs/full` log).
+Global options: `--config FILE`, `--mapping-out FILE`, `--structural-only`,
+`-o/--output FILE`. Requires Python 3 only (standard library).
 
-Requires Python 3 only (standard library).
+### Config file (JSON)
+
+```json
+{
+  "literals": ["acmecorp"],
+  "domains": ["instance1.voip2.acmecorp.com"],
+  "headers": ["X-CUSTOMER-ID"],
+  "phone_country": "FR",
+  "patterns": [{"pattern": "secret-\\d+", "replacement": "REDACTED"}]
+}
+```
+
+- `literals` / `domains` — strings redacted everywhere (consistent tokens).
+- `headers` — the value of these PJSIP headers (in gdb arg dumps) is redacted.
+- `phone_country` — opt into a per-country national-number pattern (currently
+  `FR`). National numbers are otherwise not caught; see design notes below.
+- `patterns` — raw regex→replacement escape hatch, applied last.
 
 ## Tests
 
 `test_sanitize_coredump.py` asserts that every redaction pattern actually fires
-on representative input — for a sanitizer a silent non-firing rule is a leak.
-Run with `pytest` from this directory.
+on representative input (a silent non-firing rule is a leak), plus token
+consistency/distinctness, idempotency (generated tokens are never re-matched),
+config-literal redaction, and the CLI's config-gate warning and mapping
+handling. Run with `pytest` from this directory.
 
-## Generalizing beyond this incident
+## Design notes & open items
 
-The reusable core here is the line sanitizer. Turning it into a general-purpose
-tool (config-driven customer literals, per-country phone handling, consistent
-pseudonymization, a CLI) is designed in [`GENERALIZATION-PLAN.md`](./GENERALIZATION-PLAN.md).
+- **National phone numbers** are redacted only when `phone_country` is set,
+  because a single national regex is not generic — number plans differ per
+  country (length, leading digits, trunk prefix). E.164 numbers and the
+  `callerid`/`value=` context rules are always covered; do not assume bare
+  national numbers are caught otherwise. Future options: more per-country
+  patterns, context-aware detection, or a vetted library (`phonenumbers`).
+- **Pseudonymization is counter-based, not hashed**, on purpose: a
+  phone-number / numeric-id space is trivially brute-forced and a leaked salt
+  would de-anonymize everything. The reverse map stays out of published output
+  by construction (only `--mapping-out`).
+
+The earlier incident-specific report builder (the 20XX-XX-XX customer deadlock
+narrative, frame selection, `res_freeze_check` marker) was intentionally
+dropped here; it remains in git history (commits `d2dad71` / `f8e7885`).

--- a/sanitize-coredump/README.md
+++ b/sanitize-coredump/README.md
@@ -1,0 +1,41 @@
+# sanitize-coredump
+
+Extract and anonymize relevant Asterisk coredump snippets so they can be shared
+in a public/upstream bug report without leaking customer-identifying data
+(phone numbers, public IPs, hostnames, endpoint/trunk names, tenant UUIDs, ...).
+
+It reads [`ast_coredumper`](https://github.com/asterisk/asterisk/blob/master/contrib/scripts/ast_coredumper)
+output (`*-brief.txt`, `*-info.txt`) together with the Asterisk `full` log,
+redacts sensitive tokens line-by-line, and writes:
+
+- `sanitized-coredump-excerpts.md` — a curated report (deadlock threads,
+  endpoint config evidence, log around the crash, system-state summary)
+- `sanitized-info.txt` — the full `info.txt` with the same redaction applied
+
+## Status: incident-specific template
+
+This script was written for a specific incident (the 20XX-XX-XX customer upgrade
+deadlock) and is **not** a general-purpose tool. Several things are hardcoded
+and must be adapted before reuse:
+
+- `prefix` — the `core-asterisk-<timestamp>` filename prefix (in `main()`)
+- the thread LWPs of interest (`834925`, `816915`)
+- the crash marker used to locate the log excerpt (`res_freeze_check ...
+  failed to acquire`)
+- customer-specific redaction patterns (`customer_trunk_*`,
+  `instance*.voip*.customer.com`)
+
+Keep it as a starting point: copy it, adjust the patterns and the extraction
+logic to the coredump at hand, then run it.
+
+## Usage
+
+```sh
+./sanitize-coredump.py [DIR]
+```
+
+`DIR` defaults to the current directory and must contain the
+`ast_coredumper` output files (and optionally the
+`instance-1-logs/instance-1-asterisk-logs/full` log).
+
+Requires Python 3 only (standard library).

--- a/sanitize-coredump/sanitize-coredump.py
+++ b/sanitize-coredump/sanitize-coredump.py
@@ -154,8 +154,11 @@ class Sanitizer:
                 lambda m: m.group(1) + '"' + tok('CUSTID', m.group(2)) + '"',
             ),
             (
-                re.compile(r'(PJSIP/)([A-Za-z0-9]{6,10})(@|/|-)'),
-                lambda m: m.group(1) + tok('ENDPOINT', m.group(2)) + m.group(3),
+                # endpoint terminates at any non-word char (@ / - & , ; space
+                # ...); excluding '_' keeps generated TAG_n tokens from
+                # re-matching (idempotency).
+                re.compile(r'(PJSIP/)([A-Za-z0-9]{6,10})(?![A-Za-z0-9_])'),
+                lambda m: m.group(1) + tok('ENDPOINT', m.group(2)),
             ),
             (
                 re.compile(r'(stasis/p:mwi:all/)(\d+@\S+)'),

--- a/sanitize-coredump/sanitize-coredump.py
+++ b/sanitize-coredump/sanitize-coredump.py
@@ -1,102 +1,225 @@
 #!/usr/bin/env python3
-"""Extract and anonymize relevant coredump snippets for upstream bug report.
+"""Sanitize Asterisk coredump / log excerpts for public sharing.
 
-Reads ast_coredumper output files (brief.txt, info.txt) and Asterisk logs,
-then produces sanitized excerpts suitable for public sharing.
+Redacts PII and customer-identifying tokens (phone numbers, public IPs,
+hostnames, endpoint/trunk names, tenant ids, UUIDs, ...) from ast_coredumper
+output and Asterisk logs before they go into an upstream/public bug report.
+
+Two layers of redaction:
+
+- a built-in structural ruleset for generic Asterisk/Wazo identifiers and PII
+  (always on);
+- caller-supplied literals from --config (brand names, vanity domains, tenant
+  ids, custom SIP headers) which CANNOT be inferred from shape alone.
+
+Sensitive values are replaced with stable counter-based tokens (ENDPOINT_1,
+UUID_2, ...) so that correlation survives sanitization — the same endpoint
+keeps the same token across threads — while identity is removed. The reverse
+mapping is the de-anonymization key; it is written only to --mapping-out,
+never to the sanitized output.
+
+The original incident-specific report builder (deadlock narrative, frame
+selection, res_freeze_check marker) was intentionally dropped in this
+generalization; it remains in git history (commits d2dad71 / f8e7885).
 """
 
+import argparse
+import json
 import re
 import sys
 from pathlib import Path
+from typing import Callable
 
-# Patterns to redact
-PHONE_E164 = re.compile(r'\+\d{10,15}')
-PHONE_NATIONAL = re.compile(r'\b0[1-9]\d{9,10}\b')
-# Customer-identifying trunk/endpoint names: customer_trunk_<uuid>
-CUSTOMER_TRUNK = re.compile(r'customer_trunk_[0-9a-f-]+')
-# Short endpoint tokens (8-char alphanum used as PJSIP endpoint names)
-# Only match when in PJSIP context to avoid false positives
-PJSIP_ENDPOINT = re.compile(r'(PJSIP/)([A-Za-z0-9]{6,10})(@|/|-)')
-# Customer ID values (numeric, in X-CUSTOMER-ID context)
-CUSTOMER_ID_VAL = re.compile(
-    r'("PJSIP_HEADER\(add,X-CUSTOMER-ID\)", value=0x[0-9a-f]+ )"[0-9]+"'
-)
-HEADER_VAL = re.compile(r'(data=0x[0-9a-f]+ "add", value=0x[0-9a-f]+ )"[0-9]+"')
-# Bare numeric string values (customer IDs etc.) in value= arguments
-VALUE_NUMERIC = re.compile(r'(value=[^ ]+ )"(\d{6,})"')
-# Hostname
-CUSTOMER_HOST = re.compile(r'instance\d+\.voip\d+\.customer\.com')
-# Public IPs (not RFC1918, not loopback, not documentation range)
-PUBLIC_IP = re.compile(
-    r'\b(?!10\.)(?!172\.(?:1[6-9]|2\d|3[01])\.)(?!192\.168\.)(?!127\.)(?!192\.0\.2\.)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b'
-)
-# Personal names in SIP From display names won't appear in brief.txt thread excerpts
-# but guard against them anyway
-SIP_DISPLAY_NAME = re.compile(r'"([A-Z][a-z]+ [A-Z][a-z]+)"')
-# callerid in ast_spawn_extension
-CALLERID_ARG = re.compile(r'(callerid=0x[0-9a-f]+ )"\+?\d{10,15}"')
-# Context names with tenant IDs
-CTX_ID = re.compile(r'ctx-ID\d+-')
-# Wazo app UUIDs
-WAZO_APP = re.compile(r'wazo-app-[0-9a-f-]+')
-# Endpoint tokens in taskprocessor/channel names (8-char alphanum)
-# e.g. pjsip/options/ABcD1234-00000040, pjsip/outsess/ABcD1234-00000040
-TP_ENDPOINT = re.compile(r'(pjsip/(?:options|outsess)/)([A-Za-z0-9]{6,10})(-)')
-# stasis/p:mwi:all/<ext>@<context>-<tp_hex>
-# Formats: <num>@ctx-ID<num>-internal-<hex>-<hex>-<tp>
-#          <num>@default-internal-<token>-<tp>
-#          <num>@ctx-<token>-internal-<hex>-<hex>-<tp>
-MWI_SUB = re.compile(r'(stasis/p:mwi:all/)\d+@\S+')
-# Local channel with endpoint token: Local/<token>@context
-LOCAL_CHAN_ENDPOINT = re.compile(r'(Local/)[A-Za-z0-9]{6,10}(@)')
-# PJSIP channel names: PJSIP/<endpoint>-<hex>
-PJSIP_CHAN = re.compile(r'(PJSIP/)([A-Za-z0-9]{6,10})(-[0-9a-f]+)')
-# Bridge UUIDs (standalone UUID pattern in bridge/channel table)
-BRIDGE_UUID = re.compile(
-    r'\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b'
-)
-# grp-ID<num>-<uuid> group identifiers
-GRP_ID = re.compile(r'grp-ID\d+-[0-9a-f-]+')
-# dial_mobile data: dial_mobile,<action>,<endpoint>
-DIAL_MOBILE = re.compile(r'(dial_mobile,\w+,)[A-Za-z0-9]{6,10}')
-# Dial string with SIP contact URI: sip:<user>@<ip>:<port>
-SIP_CONTACT = re.compile(r'sip:[A-Za-z0-9]+@[\d.]+:\d+[^)\s]*')
-# wazo-dial-mobile-<uuid>
-WAZO_DIAL_MOBILE = re.compile(r'wazo-dial-mobile-[0-9a-f-]+')
+# A redaction rule: a compiled pattern and a replacement (str or match->str).
+Replacement = Callable[[re.Match], str] | str
+Rule = tuple[re.Pattern, Replacement]
+
+# Per-country national number plans (opt-in via config phone_country). A single
+# national regex is not generic; bare national numbers are NOT redacted unless a
+# country is configured. Rely otherwise on PHONE_E164 and the callerid/value=
+# context rules.
+NATIONAL_PHONE_PATTERNS = {
+    'FR': re.compile(r'\b0[1-9]\d{8}\b'),
+}
 
 
-def anonymize_line(line: str) -> str:
-    line = CUSTOMER_TRUNK.sub(
-        'example_trunk_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', line
-    )
-    line = CUSTOMER_HOST.sub('sip.example.com', line)
-    line = CUSTOMER_ID_VAL.sub(r'\1"XXXXXXXX"', line)
-    line = HEADER_VAL.sub(r'\1"XXXXXXXX"', line)
-    line = VALUE_NUMERIC.sub(r'\1"XXXXXXXX"', line)
-    line = CALLERID_ARG.sub(r'\1"+XXXXXXXXXXXX"', line)
-    line = SIP_DISPLAY_NAME.sub('"REDACTED NAME"', line)
-    line = PJSIP_ENDPOINT.sub(r'\1ENDPOINT\3', line)
-    line = MWI_SUB.sub(r'\1XXXXXXX@XXXXX-XXXXX', line)
-    line = CTX_ID.sub('ctx-IDXXXXXXXX-', line)
-    line = WAZO_APP.sub('wazo-app-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', line)
-    line = TP_ENDPOINT.sub(r'\1ENDPOINT\3', line)
-    line = LOCAL_CHAN_ENDPOINT.sub(r'\1ENDPOINT\2', line)
-    line = PJSIP_CHAN.sub(r'\1ENDPOINT\3', line)
-    line = GRP_ID.sub('grp-IDXXXXXXXX-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', line)
-    line = DIAL_MOBILE.sub(r'\1ENDPOINT', line)
-    line = SIP_CONTACT.sub('sip:XXXXX@X.X.X.X:XXXXX', line)
-    line = WAZO_DIAL_MOBILE.sub(
-        'wazo-dial-mobile-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', line
-    )
-    line = PHONE_E164.sub('+XXXXXXXXXXXX', line)
-    line = PHONE_NATIONAL.sub('0XXXXXXXXXX', line)
-    line = PUBLIC_IP.sub('X.X.X.X', line)
-    line = BRIDGE_UUID.sub('XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', line)
-    return line
+class Pseudonymizer:
+    """Maps each distinct sensitive value to a stable counter-based token.
+
+    Counter-based (not hashed) on purpose: a phone-number / numeric-id space is
+    trivially brute-forced, and a leaked salt would de-anonymize everything.
+    """
+
+    def __init__(self) -> None:
+        self._counters: dict[str, int] = {}
+        self._tokens: dict[tuple[str, str], str] = {}
+
+    def token(self, tag: str, value: str) -> str:
+        key = (tag, value)
+        token = self._tokens.get(key)
+        if token is None:
+            count = self._counters.get(tag, 0) + 1
+            self._counters[tag] = count
+            token = f'{tag}_{count}'
+            self._tokens[key] = token
+        return token
+
+    def mapping(self) -> dict[str, str]:
+        """Reverse map token -> original value (the de-anonymization key)."""
+        return {token: value for (_, value), token in self._tokens.items()}
+
+
+class Sanitizer:
+    def __init__(
+        self,
+        pseudo: Pseudonymizer | None = None,
+        literals: tuple[str, ...] = (),
+        domains: tuple[str, ...] = (),
+        headers: tuple[str, ...] = (),
+        extra_patterns: tuple[tuple[str, str], ...] = (),
+        phone_country: str | None = None,
+    ) -> None:
+        self.pseudo = pseudo or Pseudonymizer()
+        self._rules = self._build_rules(
+            literals, domains, headers, extra_patterns, phone_country
+        )
+
+    def _build_rules(
+        self,
+        literals: tuple[str, ...],
+        domains: tuple[str, ...],
+        headers: tuple[str, ...],
+        extra_patterns: tuple[tuple[str, str], ...],
+        phone_country: str | None,
+    ) -> list[Rule]:
+        tok = self.pseudo.token
+        rules: list[Rule] = []
+
+        # --- caller-supplied literals (longest first to avoid partial shadowing)
+        for domain in sorted(set(domains), key=len, reverse=True):
+            rules.append(
+                (re.compile(re.escape(domain)), lambda m: tok('HOST', m.group(0)))
+            )
+        for literal in sorted(set(literals), key=len, reverse=True):
+            rules.append(
+                (re.compile(re.escape(literal)), lambda m: tok('LITERAL', m.group(0)))
+            )
+        for header in headers:
+            rx = re.compile(
+                r'("PJSIP_HEADER\([^,]+,'
+                + re.escape(header)
+                + r'\)", value=0x[0-9a-f]+ )"([^"]*)"'
+            )
+            rules.append(
+                (rx, lambda m: m.group(1) + '"' + tok('HEADERVAL', m.group(2)) + '"')
+            )
+
+        # --- built-in structural ruleset (order is load-bearing) ---
+        rules += [
+            (
+                re.compile(r'"([A-Z][a-z]+ [A-Z][a-z]+)"'),
+                lambda m: '"' + tok('NAME', m.group(1)) + '"',
+            ),
+            (
+                re.compile(r'(callerid=0x[0-9a-f]+ )"\+?(\d{10,15})"'),
+                lambda m: m.group(1) + '"' + tok('PHONE', m.group(2)) + '"',
+            ),
+            (
+                re.compile(r'(value=[^ ]+ )"(\d{6,})"'),
+                lambda m: m.group(1) + '"' + tok('CUSTID', m.group(2)) + '"',
+            ),
+            (
+                re.compile(r'(PJSIP/)([A-Za-z0-9]{6,10})(@|/|-)'),
+                lambda m: m.group(1) + tok('ENDPOINT', m.group(2)) + m.group(3),
+            ),
+            (
+                re.compile(r'(stasis/p:mwi:all/)(\d+@\S+)'),
+                lambda m: m.group(1) + tok('MWISUB', m.group(2)),
+            ),
+            (
+                re.compile(r'(ctx-ID)(\d+)'),
+                lambda m: m.group(1) + tok('TENANT', m.group(2)),
+            ),
+            (
+                re.compile(r'(wazo-app-)([0-9a-f-]+)'),
+                lambda m: m.group(1) + tok('UUID', m.group(2)),
+            ),
+            (
+                re.compile(r'(pjsip/(?:options|outsess)/)([A-Za-z0-9]{6,10})(-)'),
+                lambda m: m.group(1) + tok('ENDPOINT', m.group(2)) + m.group(3),
+            ),
+            (
+                re.compile(r'(Local/)([A-Za-z0-9]{6,10})(@)'),
+                lambda m: m.group(1) + tok('ENDPOINT', m.group(2)) + m.group(3),
+            ),
+            (
+                re.compile(r'(PJSIP/)([A-Za-z0-9]{6,10})(-[0-9a-f]+)'),
+                lambda m: m.group(1) + tok('ENDPOINT', m.group(2)) + m.group(3),
+            ),
+            (
+                re.compile(r'grp-ID\d+-[0-9a-f-]+'),
+                lambda m: tok('GRP', m.group(0)),
+            ),
+            (
+                re.compile(r'(dial_mobile,\w+,)([A-Za-z0-9]{6,10})\b'),
+                lambda m: m.group(1) + tok('ENDPOINT', m.group(2)),
+            ),
+            (
+                re.compile(r'sip:[A-Za-z0-9]+@[\d.]+:\d+[^)\s]*'),
+                lambda m: tok('CONTACT', m.group(0)),
+            ),
+            (
+                re.compile(r'wazo-dial-mobile-[0-9a-f-]+'),
+                lambda m: tok('WAZODIAL', m.group(0)),
+            ),
+        ]
+
+        if phone_country:
+            national = NATIONAL_PHONE_PATTERNS.get(phone_country)
+            if national is None:
+                raise ValueError(
+                    f'unknown phone_country {phone_country!r}; known: '
+                    f'{sorted(NATIONAL_PHONE_PATTERNS)}'
+                )
+            rules.append((national, lambda m: tok('PHONE', m.group(0))))
+
+        rules += [
+            (re.compile(r'\+\d{10,15}'), lambda m: tok('PHONE', m.group(0))),
+            (
+                re.compile(
+                    r'\b(?!10\.)(?!172\.(?:1[6-9]|2\d|3[01])\.)(?!192\.168\.)'
+                    r'(?!127\.)(?!192\.0\.2\.)'
+                    r'(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b'
+                ),
+                lambda m: tok('IP', m.group(1)),
+            ),
+            (
+                re.compile(
+                    r'\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-'
+                    r'[0-9a-f]{4}-[0-9a-f]{12}\b'
+                ),
+                lambda m: tok('UUID', m.group(0)),
+            ),
+        ]
+
+        # --- caller-supplied raw regex escape hatch (applied last) ---
+        rules += [(re.compile(pat), repl) for pat, repl in extra_patterns]
+
+        return rules
+
+    def line(self, text: str) -> str:
+        for pattern, repl in self._rules:
+            text = pattern.sub(repl, text)
+        return text
+
+
+def anonymize_line(text: str) -> str:
+    """Structural-only sanitization of a single line (no caller config)."""
+    return Sanitizer().line(text)
 
 
 def extract_thread(lines: list[str], lwp: int) -> list[str]:
-    """Extract a single thread's backtrace from brief.txt lines."""
+    """Extract a single thread's backtrace from brief.txt lines by LWP."""
     result = []
     in_thread = False
     for line in lines:
@@ -109,32 +232,24 @@ def extract_thread(lines: list[str], lwp: int) -> list[str]:
     return result
 
 
-def extract_system_summary(info_path: Path) -> str:
-    """Extract anonymized system state summary from info.txt."""
-    text = info_path.read_text()
-    lines = text.splitlines()
+def extract_system_summary(info_path: Path, sanitizer: Sanitizer) -> str:
+    """Extract a sanitized system-state summary from an info.txt."""
+    lines = info_path.read_text().splitlines()
+    summary: list[str] = []
 
-    summary_lines = []
+    for line in lines[2:7]:  # header: version, build, uptime
+        summary.append(sanitizer.line(line))
 
-    # Header (version, build, uptime)
-    for line in lines[2:7]:
-        summary_lines.append(anonymize_line(line))
-
-    # TaskProcessors total
     for line in lines:
         if line.startswith('TaskProcessors ('):
-            summary_lines.append('')
-            summary_lines.append(line)
+            summary += ['', line]
             break
 
-    # Table header
     for line in lines:
         if line.startswith('Processor'):
-            summary_lines.append('')
-            summary_lines.append(line)
+            summary += ['', line]
             break
 
-    # Non-sensitive taskprocessors: list individually
     safe_prefixes = (
         'app_voicemail',
         'ast_msg_queue',
@@ -148,16 +263,13 @@ def extract_system_summary(info_path: Path) -> str:
         'pjsip/mwi',
     )
     for line in lines:
-        for pfx in safe_prefixes:
-            if line.startswith(pfx):
-                summary_lines.append(line)
-                break
+        if line.startswith(safe_prefixes):
+            summary.append(line)
 
-    # Summarize categories with counts
     tp_lines = [
         ln for ln in lines if not ln.startswith('Processor') and not ln.startswith('!')
     ]
-    categories = {
+    categories: dict[str, list[str]] = {
         'pjsip/options': [],
         'pjsip/outsess': [],
         'stasis/m:ari:application': [],
@@ -177,148 +289,168 @@ def extract_system_summary(info_path: Path) -> str:
         elif stripped.startswith('stasis/'):
             categories['stasis (other)'].append(stripped)
 
-    summary_lines.append('')
-    summary_lines.append('Taskprocessor categories (names anonymized):')
+    summary += ['', 'Taskprocessor categories (names anonymized):']
     for cat, cat_lines in categories.items():
         if not cat_lines:
             continue
-        # Parse numeric columns for aggregate stats
         queued_total = 0
-        max_depth_max = 0
+        max_depth = 0
         for cl in cat_lines:
             parts = cl.split()
             if len(parts) >= 4:
                 try:
                     queued_total += int(parts[-4])
-                    max_depth_max = max(max_depth_max, int(parts[-3]))
+                    max_depth = max(max_depth, int(parts[-3]))
                 except (ValueError, IndexError):
                     pass
-        summary_lines.append(
+        summary.append(
             f'  {cat}: {len(cat_lines)} taskprocessors, '
-            f'{queued_total} total in queue, '
-            f'max depth {max_depth_max}'
+            f'{queued_total} total in queue, max depth {max_depth}'
         )
 
-    # Channels and bridges count
-    summary_lines.append('')
+    summary.append('')
     for line in lines:
         if line.startswith('Channels (') or line.startswith('Bridges ('):
-            summary_lines.append(line)
+            summary.append(line)
 
-    return '\n'.join(summary_lines)
-
-
-def extract_log_around_crash(
-    log_path: Path, before: int = 5, after: int = 5
-) -> list[str]:
-    """Extract log lines around the crash timestamp."""
-    lines = log_path.read_text().splitlines()
-    # Find the freeze_check error line
-    crash_idx = None
-    for i, line in enumerate(lines):
-        if 'res_freeze_check' in line and 'failed to acquire' in line:
-            crash_idx = i
-            break
-    if crash_idx is None:
-        return ['(res_freeze_check message not found in log)']
-
-    start = max(0, crash_idx - before)
-    end = min(len(lines), crash_idx + after + 1)
-    return [anonymize_line(ln) for ln in lines[start:end]]
+    return '\n'.join(summary)
 
 
-def extract_endpoint_config_evidence(brief_lines: list[str], lwp: int) -> list[str]:
-    """Extract the key frames showing set_var -> PJSIP_HEADER code path."""
-    thread = extract_thread(brief_lines, lwp)
-    # Pick frames #7-#10 which show the set_var -> PJSIP_HEADER -> chan_pjsip_new path
-    evidence = []
-    for line in thread:
-        for frame in ('#7 ', '#8 ', '#9 ', '#10 '):
-            if line.startswith(frame):
-                evidence.append(anonymize_line(line))
-    return evidence
+def load_config(path: Path) -> dict:
+    config = json.loads(path.read_text())
+    if not isinstance(config, dict):
+        raise ValueError('config must be a JSON object')
+    return config
 
 
-def main():
-    base = Path(sys.argv[1]) if len(sys.argv) > 1 else Path('.')
-    prefix = 'core-asterisk-<timestamp>'
-
-    brief_path = base / f'{prefix}-brief.txt'
-    info_path = base / f'{prefix}-info.txt'
-    log_path = base / 'instance-1-logs' / 'instance-1-asterisk-logs' / 'full'
-
-    brief_lines = brief_path.read_text().splitlines()
-
-    # Thread LWPs from the crash analysis
-    # Thread 1158 (LWP 834925) - Dial thread holding channel lock
-    # Thread 780 (LWP 816915) - ARI thread holding container lock
-    dial_thread = extract_thread(brief_lines, 834925)
-    ari_thread = extract_thread(brief_lines, 816915)
-
-    output = []
-    output.append('# Sanitized coredump excerpts for upstream bug report')
-    output.append('')
-
-    # Endpoint set_var evidence
-    output.append('## Evidence of endpoint set_var configuration')
-    output.append('')
-    output.append(
-        'The stack trace shows `PJSIP_HEADER(add,X-CUSTOMER-ID)` being called from'
+def build_sanitizer(config: dict | None) -> Sanitizer:
+    config = config or {}
+    extra = tuple(
+        (entry['pattern'], entry['replacement']) for entry in config.get('patterns', [])
     )
-    output.append(
-        '`chan_pjsip_new()` via the endpoint `channel_vars` loop (set_var config):'
+    return Sanitizer(
+        literals=tuple(config.get('literals', [])),
+        domains=tuple(config.get('domains', [])),
+        headers=tuple(config.get('headers', [])),
+        extra_patterns=extra,
+        phone_country=config.get('phone_country'),
     )
-    output.append('```')
-    for line in extract_endpoint_config_evidence(brief_lines, 834925):
-        output.append(line)
-    output.append('```')
-    output.append('')
 
-    # Deadlock threads
-    output.append(
-        '## Thread A: Dial / chan_pjsip_new — holds channel lock, waiting on serializer'
+
+def _emit(text: str, output: str | None) -> None:
+    if output:
+        Path(output).write_text(text + '\n' if text else '')
+    else:
+        sys.stdout.write(text + '\n' if text else '')
+
+
+def _cmd_filter(args: argparse.Namespace, sanitizer: Sanitizer) -> None:
+    files = args.files or ['-']
+    out_lines = []
+    for name in files:
+        handle = sys.stdin if name == '-' else open(name, encoding='utf-8')
+        try:
+            for line in handle:
+                out_lines.append(sanitizer.line(line.rstrip('\n')))
+        finally:
+            if handle is not sys.stdin:
+                handle.close()
+    _emit('\n'.join(out_lines), args.output)
+
+
+def _cmd_thread(args: argparse.Namespace, sanitizer: Sanitizer) -> None:
+    lines = Path(args.brief).read_text().splitlines()
+    out: list[str] = []
+    for lwp in args.lwp:
+        out += [sanitizer.line(line) for line in extract_thread(lines, lwp)]
+    _emit('\n'.join(out), args.output)
+
+
+def _cmd_log(args: argparse.Namespace, sanitizer: Sanitizer) -> None:
+    lines = Path(args.logfile).read_text().splitlines()
+    marker = re.compile(args.marker)
+    idx = next((i for i, line in enumerate(lines) if marker.search(line)), None)
+    if idx is None:
+        sys.exit(f'marker {args.marker!r} not found in {args.logfile}')
+    start = max(0, idx - args.before)
+    end = min(len(lines), idx + args.after + 1)
+    _emit('\n'.join(sanitizer.line(line) for line in lines[start:end]), args.output)
+
+
+def _cmd_summary(args: argparse.Namespace, sanitizer: Sanitizer) -> None:
+    _emit(extract_system_summary(Path(args.info), sanitizer), args.output)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=(__doc__ or '').splitlines()[0])
+    parser.add_argument('--config', type=Path, help='JSON config of caller literals')
+    parser.add_argument(
+        '--mapping-out',
+        type=Path,
+        help='write the token->value de-anonymization key here (keep private)',
     )
-    output.append('```')
-    for line in dial_thread:
-        output.append(anonymize_line(line))
-    output.append('```')
-    output.append('')
-    output.append(
-        '## Thread B: ARI GET channel variable — holds container lock, '
-        'waiting on channel lock'
+    parser.add_argument(
+        '--structural-only',
+        action='store_true',
+        help='acknowledge running without caller literals (suppresses warning)',
     )
-    output.append('```')
-    for line in ari_thread:
-        output.append(anonymize_line(line))
-    output.append('```')
-    output.append('')
+    parser.add_argument('-o', '--output', help='write to file instead of stdout')
 
-    # Log excerpt
-    if log_path.exists():
-        output.append('## Asterisk log around crash time')
-        output.append('```')
-        for line in extract_log_around_crash(log_path):
-            output.append(line)
-        output.append('```')
-        output.append('')
+    sub = parser.add_subparsers(dest='cmd', required=True)
 
-    # System state
-    output.append('## System state at crash')
-    output.append('```')
-    output.append(extract_system_summary(info_path))
-    output.append('```')
+    p_filter = sub.add_parser('filter', help='sanitize lines from files or stdin')
+    p_filter.add_argument('files', nargs='*', help='input files (default: stdin)')
+    p_filter.set_defaults(func=_cmd_filter)
 
-    result = '\n'.join(output)
-    out_path = base / 'sanitized-coredump-excerpts.md'
-    out_path.write_text(result + '\n')
-    print(f'Written to {out_path}')
+    p_thread = sub.add_parser('thread', help='extract & sanitize thread(s) by LWP')
+    p_thread.add_argument('brief', help='ast_coredumper brief.txt')
+    p_thread.add_argument(
+        '--lwp',
+        type=int,
+        action='append',
+        required=True,
+        help='thread LWP (repeatable)',
+    )
+    p_thread.set_defaults(func=_cmd_thread)
 
-    # Anonymized info.txt (full structure preserved)
-    info_lines = info_path.read_text().splitlines()
-    anon_info = '\n'.join(anonymize_line(ln) for ln in info_lines)
-    anon_info_path = base / 'sanitized-info.txt'
-    anon_info_path.write_text(anon_info + '\n')
-    print(f'Written to {anon_info_path}')
+    p_log = sub.add_parser('log', help='extract & sanitize log lines around a marker')
+    p_log.add_argument('logfile')
+    p_log.add_argument(
+        '--marker', required=True, help='regex marking the line of interest'
+    )
+    p_log.add_argument('--before', type=int, default=5)
+    p_log.add_argument('--after', type=int, default=5)
+    p_log.set_defaults(func=_cmd_log)
+
+    p_summary = sub.add_parser('summary', help='sanitized system-state summary')
+    p_summary.add_argument('info', help='ast_coredumper info.txt')
+    p_summary.set_defaults(func=_cmd_summary)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _build_parser().parse_args(argv)
+    config = load_config(args.config) if args.config else None
+
+    has_literals = bool(
+        config
+        and (config.get('literals') or config.get('domains') or config.get('headers'))
+    )
+    if not has_literals and not args.structural_only:
+        print(
+            'WARNING: no caller literals configured (--config). Brand names, '
+            'vanity hostnames, tenant slugs and custom header values will NOT '
+            'be redacted — only generic structural patterns. Pass --config or '
+            '--structural-only to acknowledge.',
+            file=sys.stderr,
+        )
+
+    sanitizer = build_sanitizer(config)
+    args.func(args, sanitizer)
+
+    if args.mapping_out:
+        args.mapping_out.write_text(json.dumps(sanitizer.pseudo.mapping(), indent=2))
 
 
 if __name__ == '__main__':

--- a/sanitize-coredump/sanitize-coredump.py
+++ b/sanitize-coredump/sanitize-coredump.py
@@ -24,6 +24,7 @@ generalization; it remains in git history (commits d2dad71 / f8e7885).
 """
 
 import argparse
+import io
 import json
 import re
 import sys
@@ -40,7 +41,25 @@ Rule = tuple[re.Pattern, Replacement]
 # context rules.
 NATIONAL_PHONE_PATTERNS = {
     'FR': re.compile(r'\b0[1-9]\d{8}\b'),
+    'UK': re.compile(r'\b0\d{9,10}\b'),
 }
+
+
+def _truncatable_domain_regex(domain: str) -> str:
+    """Regex matching ``domain`` or any gdb-truncated prefix of it.
+
+    gdb cuts long strings at arbitrary points (``instance1.v"...``), so an
+    exact match misses the fragments. Keep a fixed head (the first dot-label,
+    at least 7 chars so a short generic prefix is not over-matched) and make
+    every following character independently optional.
+    """
+    labels = domain.split('.')
+    head_len = min(len(domain), max(len(labels[0]), 7))
+    head = re.escape(domain[:head_len])
+    tail = ''
+    for char in reversed(domain[head_len:]):
+        tail = f'(?:{re.escape(char)}{tail})?'
+    return head + tail
 
 
 class Pseudonymizer:
@@ -95,14 +114,13 @@ class Sanitizer:
         tok = self.pseudo.token
         rules: list[Rule] = []
 
-        # --- caller-supplied literals (longest first to avoid partial shadowing)
+        # --- caller-supplied domains and headers (specific contexts, run early)
         for domain in sorted(set(domains), key=len, reverse=True):
             rules.append(
-                (re.compile(re.escape(domain)), lambda m: tok('HOST', m.group(0)))
-            )
-        for literal in sorted(set(literals), key=len, reverse=True):
-            rules.append(
-                (re.compile(re.escape(literal)), lambda m: tok('LITERAL', m.group(0)))
+                (
+                    re.compile(_truncatable_domain_regex(domain)),
+                    lambda m: tok('HOST', m.group(0)),
+                )
             )
         for header in headers:
             rx = re.compile(
@@ -116,6 +134,13 @@ class Sanitizer:
 
         # --- built-in structural ruleset (order is load-bearing) ---
         rules += [
+            # Wazo trunk endpoint names <slug>_trunk_<hexid>; the slug AND the
+            # per-trunk id are customer-correlating, so token the whole name.
+            # Runs before the brand-literal rule so the slug is captured here.
+            (
+                re.compile(r'[A-Za-z0-9]+_trunk_[0-9a-f](?:[0-9a-f-]*[0-9a-f])?'),
+                lambda m: tok('TRUNK', m.group(0)),
+            ),
             (
                 re.compile(r'"([A-Z][a-z]+ [A-Z][a-z]+)"'),
                 lambda m: '"' + tok('NAME', m.group(1)) + '"',
@@ -194,13 +219,26 @@ class Sanitizer:
                 lambda m: tok('IP', m.group(1)),
             ),
             (
+                # UUID-shaped identifiers. The tail length is intentionally
+                # loose ([0-9a-f]+, not {12}) because real data carries
+                # truncated trunk UUIDs (8-4-4-4-9). No leading \b either: UUIDs
+                # appear glued to a prefix in SIP Via branches
+                # (z9hG4bKPj<uuid>). Over-redact rather than miss a
+                # customer-correlating id.
                 re.compile(
-                    r'\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-'
-                    r'[0-9a-f]{4}-[0-9a-f]{12}\b'
+                    r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]+'
                 ),
                 lambda m: tok('UUID', m.group(0)),
             ),
         ]
+
+        # --- caller-supplied brand literals (generic substrings, run late so
+        # they only catch standalone mentions, not parts of compound names
+        # already tokenized above; longest first to avoid partial shadowing)
+        for literal in sorted(set(literals), key=len, reverse=True):
+            rules.append(
+                (re.compile(re.escape(literal)), lambda m: tok('LITERAL', m.group(0)))
+            )
 
         # --- caller-supplied raw regex escape hatch (applied last) ---
         rules += [(re.compile(pat), repl) for pat, repl in extra_patterns]
@@ -234,7 +272,7 @@ def extract_thread(lines: list[str], lwp: int) -> list[str]:
 
 def extract_system_summary(info_path: Path, sanitizer: Sanitizer) -> str:
     """Extract a sanitized system-state summary from an info.txt."""
-    lines = info_path.read_text().splitlines()
+    lines = _read_text(info_path).splitlines()
     summary: list[str] = []
 
     for line in lines[2:7]:  # header: version, build, uptime
@@ -316,6 +354,18 @@ def extract_system_summary(info_path: Path, sanitizer: Sanitizer) -> str:
     return '\n'.join(summary)
 
 
+def _read_text(path: str | Path) -> str:
+    # Coredump logs routinely contain non-UTF-8 bytes; replace them rather than
+    # crash (and never round-trip raw bytes into the sanitized output).
+    return Path(path).read_text(encoding='utf-8', errors='replace')
+
+
+def _open_text(name: str) -> io.TextIOBase:
+    if name == '-':
+        return io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8', errors='replace')
+    return open(name, encoding='utf-8', errors='replace')
+
+
 def load_config(path: Path) -> dict:
     config = json.loads(path.read_text())
     if not isinstance(config, dict):
@@ -348,18 +398,18 @@ def _cmd_filter(args: argparse.Namespace, sanitizer: Sanitizer) -> None:
     files = args.files or ['-']
     out_lines = []
     for name in files:
-        handle = sys.stdin if name == '-' else open(name, encoding='utf-8')
+        handle = _open_text(name)
         try:
             for line in handle:
                 out_lines.append(sanitizer.line(line.rstrip('\n')))
         finally:
-            if handle is not sys.stdin:
+            if name != '-':
                 handle.close()
     _emit('\n'.join(out_lines), args.output)
 
 
 def _cmd_thread(args: argparse.Namespace, sanitizer: Sanitizer) -> None:
-    lines = Path(args.brief).read_text().splitlines()
+    lines = _read_text(args.brief).splitlines()
     out: list[str] = []
     for lwp in args.lwp:
         out += [sanitizer.line(line) for line in extract_thread(lines, lwp)]
@@ -367,7 +417,7 @@ def _cmd_thread(args: argparse.Namespace, sanitizer: Sanitizer) -> None:
 
 
 def _cmd_log(args: argparse.Namespace, sanitizer: Sanitizer) -> None:
-    lines = Path(args.logfile).read_text().splitlines()
+    lines = _read_text(args.logfile).splitlines()
     marker = re.compile(args.marker)
     idx = next((i for i, line in enumerate(lines) if marker.search(line)), None)
     if idx is None:

--- a/sanitize-coredump/sanitize-coredump.py
+++ b/sanitize-coredump/sanitize-coredump.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Extract and anonymize relevant coredump snippets for upstream bug report.
+
+Reads ast_coredumper output files (brief.txt, info.txt) and Asterisk logs,
+then produces sanitized excerpts suitable for public sharing.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# Patterns to redact
+PHONE_E164 = re.compile(r'\+\d{10,15}')
+PHONE_NATIONAL = re.compile(r'\b0[1-9]\d{9,10}\b')
+# Customer-identifying trunk/endpoint names: customer_trunk_<uuid>
+CUSTOMER_TRUNK = re.compile(r'customer_trunk_[0-9a-f-]+')
+# Short endpoint tokens (8-char alphanum used as PJSIP endpoint names)
+# Only match when in PJSIP context to avoid false positives
+PJSIP_ENDPOINT = re.compile(r'(PJSIP/)([A-Za-z0-9]{6,10})(@|/|-)')
+# Customer ID values (numeric, in X-CUSTOMER-ID context)
+CUSTOMER_ID_VAL = re.compile(
+    r'("PJSIP_HEADER\(add,X-CUSTOMER-ID\)", value=0x[0-9a-f]+ )"[0-9]+"'
+)
+HEADER_VAL = re.compile(r'(data=0x[0-9a-f]+ "add", value=0x[0-9a-f]+ )"[0-9]+"')
+# Bare numeric string values (customer IDs etc.) in value= arguments
+VALUE_NUMERIC = re.compile(r'(value=[^ ]+ )"(\d{6,})"')
+# Hostname
+CUSTOMER_HOST = re.compile(r'instance\d+\.voip\d+\.customer\.com')
+# Public IPs (not RFC1918, not loopback, not documentation range)
+PUBLIC_IP = re.compile(
+    r'\b(?!10\.)(?!172\.(?:1[6-9]|2\d|3[01])\.)(?!192\.168\.)(?!127\.)(?!192\.0\.2\.)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b'
+)
+# Personal names in SIP From display names won't appear in brief.txt thread excerpts
+# but guard against them anyway
+SIP_DISPLAY_NAME = re.compile(r'"([A-Z][a-z]+ [A-Z][a-z]+)"')
+# callerid in ast_spawn_extension
+CALLERID_ARG = re.compile(r'(callerid=0x[0-9a-f]+ )"\+?\d{10,15}"')
+# Context names with tenant IDs
+CTX_ID = re.compile(r'ctx-ID\d+-')
+# Wazo app UUIDs
+WAZO_APP = re.compile(r'wazo-app-[0-9a-f-]+')
+# Endpoint tokens in taskprocessor/channel names (8-char alphanum)
+# e.g. pjsip/options/ABcD1234-00000040, pjsip/outsess/ABcD1234-00000040
+TP_ENDPOINT = re.compile(r'(pjsip/(?:options|outsess)/)([A-Za-z0-9]{6,10})(-)')
+# stasis/p:mwi:all/<ext>@<context>-<tp_hex>
+# Formats: <num>@ctx-ID<num>-internal-<hex>-<hex>-<tp>
+#          <num>@default-internal-<token>-<tp>
+#          <num>@ctx-<token>-internal-<hex>-<hex>-<tp>
+MWI_SUB = re.compile(r'(stasis/p:mwi:all/)\d+@\S+')
+# Local channel with endpoint token: Local/<token>@context
+LOCAL_CHAN_ENDPOINT = re.compile(r'(Local/)[A-Za-z0-9]{6,10}(@)')
+# PJSIP channel names: PJSIP/<endpoint>-<hex>
+PJSIP_CHAN = re.compile(r'(PJSIP/)([A-Za-z0-9]{6,10})(-[0-9a-f]+)')
+# Bridge UUIDs (standalone UUID pattern in bridge/channel table)
+BRIDGE_UUID = re.compile(
+    r'\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b'
+)
+# grp-ID<num>-<uuid> group identifiers
+GRP_ID = re.compile(r'grp-ID\d+-[0-9a-f-]+')
+# dial_mobile data: dial_mobile,<action>,<endpoint>
+DIAL_MOBILE = re.compile(r'(dial_mobile,\w+,)[A-Za-z0-9]{6,10}')
+# Dial string with SIP contact URI: sip:<user>@<ip>:<port>
+SIP_CONTACT = re.compile(r'sip:[A-Za-z0-9]+@[\d.]+:\d+[^)\s]*')
+# wazo-dial-mobile-<uuid>
+WAZO_DIAL_MOBILE = re.compile(r'wazo-dial-mobile-[0-9a-f-]+')
+
+
+def anonymize_line(line: str) -> str:
+    line = CUSTOMER_TRUNK.sub(
+        'example_trunk_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', line
+    )
+    line = CUSTOMER_HOST.sub('sip.example.com', line)
+    line = CUSTOMER_ID_VAL.sub(r'\1"XXXXXXXX"', line)
+    line = HEADER_VAL.sub(r'\1"XXXXXXXX"', line)
+    line = VALUE_NUMERIC.sub(r'\1"XXXXXXXX"', line)
+    line = CALLERID_ARG.sub(r'\1"+XXXXXXXXXXXX"', line)
+    line = PJSIP_ENDPOINT.sub(r'\1ENDPOINT\3', line)
+    line = MWI_SUB.sub(r'\1XXXXXXX@XXXXX-XXXXX', line)
+    line = CTX_ID.sub('ctx-IDXXXXXXXX-', line)
+    line = WAZO_APP.sub('wazo-app-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', line)
+    line = TP_ENDPOINT.sub(r'\1ENDPOINT\3', line)
+    line = LOCAL_CHAN_ENDPOINT.sub(r'\1ENDPOINT\2', line)
+    line = PJSIP_CHAN.sub(r'\1ENDPOINT\3', line)
+    line = GRP_ID.sub('grp-IDXXXXXXXX-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', line)
+    line = DIAL_MOBILE.sub(r'\1ENDPOINT', line)
+    line = SIP_CONTACT.sub('sip:XXXXX@X.X.X.X:XXXXX', line)
+    line = WAZO_DIAL_MOBILE.sub(
+        'wazo-dial-mobile-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', line
+    )
+    line = PHONE_E164.sub('+XXXXXXXXXXXX', line)
+    line = PHONE_NATIONAL.sub('0XXXXXXXXXX', line)
+    line = PUBLIC_IP.sub('X.X.X.X', line)
+    line = BRIDGE_UUID.sub('XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', line)
+    return line
+
+
+def extract_thread(lines: list[str], lwp: int) -> list[str]:
+    """Extract a single thread's backtrace from brief.txt lines."""
+    result = []
+    in_thread = False
+    for line in lines:
+        if f'LWP {lwp})' in line and line.startswith('Thread '):
+            in_thread = True
+        elif in_thread and line.startswith('Thread '):
+            break
+        if in_thread:
+            result.append(line)
+    return result
+
+
+def extract_system_summary(info_path: Path) -> str:
+    """Extract anonymized system state summary from info.txt."""
+    text = info_path.read_text()
+    lines = text.splitlines()
+
+    summary_lines = []
+
+    # Header (version, build, uptime)
+    for line in lines[2:7]:
+        summary_lines.append(anonymize_line(line))
+
+    # TaskProcessors total
+    for line in lines:
+        if line.startswith('TaskProcessors ('):
+            summary_lines.append('')
+            summary_lines.append(line)
+            break
+
+    # Table header
+    for line in lines:
+        if line.startswith('Processor'):
+            summary_lines.append('')
+            summary_lines.append(line)
+            break
+
+    # Non-sensitive taskprocessors: list individually
+    safe_prefixes = (
+        'app_voicemail',
+        'ast_msg_queue',
+        'CCSS_core',
+        'dns_system',
+        'hep_queue_tp',
+        'iax2_transmit',
+        'pjsip/distributor',
+        'pjsip/exten_state',
+        'pjsip/messaging',
+        'pjsip/mwi',
+    )
+    for line in lines:
+        for pfx in safe_prefixes:
+            if line.startswith(pfx):
+                summary_lines.append(line)
+                break
+
+    # Summarize categories with counts
+    tp_lines = [
+        ln for ln in lines if not ln.startswith('Processor') and not ln.startswith('!')
+    ]
+    categories = {
+        'pjsip/options': [],
+        'pjsip/outsess': [],
+        'stasis/m:ari:application': [],
+        'stasis/p:mwi:all': [],
+        'stasis (other)': [],
+    }
+    for line in tp_lines:
+        stripped = line.strip()
+        if stripped.startswith('pjsip/options/'):
+            categories['pjsip/options'].append(stripped)
+        elif stripped.startswith('pjsip/outsess/'):
+            categories['pjsip/outsess'].append(stripped)
+        elif stripped.startswith('stasis/m:ari:application/'):
+            categories['stasis/m:ari:application'].append(stripped)
+        elif stripped.startswith('stasis/p:mwi:all/'):
+            categories['stasis/p:mwi:all'].append(stripped)
+        elif stripped.startswith('stasis/'):
+            categories['stasis (other)'].append(stripped)
+
+    summary_lines.append('')
+    summary_lines.append('Taskprocessor categories (names anonymized):')
+    for cat, cat_lines in categories.items():
+        if not cat_lines:
+            continue
+        # Parse numeric columns for aggregate stats
+        queued_total = 0
+        max_depth_max = 0
+        for cl in cat_lines:
+            parts = cl.split()
+            if len(parts) >= 4:
+                try:
+                    queued_total += int(parts[-4])
+                    max_depth_max = max(max_depth_max, int(parts[-3]))
+                except (ValueError, IndexError):
+                    pass
+        summary_lines.append(
+            f'  {cat}: {len(cat_lines)} taskprocessors, '
+            f'{queued_total} total in queue, '
+            f'max depth {max_depth_max}'
+        )
+
+    # Channels and bridges count
+    summary_lines.append('')
+    for line in lines:
+        if line.startswith('Channels (') or line.startswith('Bridges ('):
+            summary_lines.append(line)
+
+    return '\n'.join(summary_lines)
+
+
+def extract_log_around_crash(
+    log_path: Path, before: int = 5, after: int = 5
+) -> list[str]:
+    """Extract log lines around the crash timestamp."""
+    lines = log_path.read_text().splitlines()
+    # Find the freeze_check error line
+    crash_idx = None
+    for i, line in enumerate(lines):
+        if 'res_freeze_check' in line and 'failed to acquire' in line:
+            crash_idx = i
+            break
+    if crash_idx is None:
+        return ['(res_freeze_check message not found in log)']
+
+    start = max(0, crash_idx - before)
+    end = min(len(lines), crash_idx + after + 1)
+    return [anonymize_line(ln) for ln in lines[start:end]]
+
+
+def extract_endpoint_config_evidence(brief_lines: list[str], lwp: int) -> list[str]:
+    """Extract the key frames showing set_var -> PJSIP_HEADER code path."""
+    thread = extract_thread(brief_lines, lwp)
+    # Pick frames #7-#10 which show the set_var -> PJSIP_HEADER -> chan_pjsip_new path
+    evidence = []
+    for line in thread:
+        for frame in ('#7 ', '#8 ', '#9 ', '#10 '):
+            if line.startswith(frame):
+                evidence.append(anonymize_line(line))
+    return evidence
+
+
+def main():
+    base = Path(sys.argv[1]) if len(sys.argv) > 1 else Path('.')
+    prefix = 'core-asterisk-<timestamp>'
+
+    brief_path = base / f'{prefix}-brief.txt'
+    info_path = base / f'{prefix}-info.txt'
+    log_path = base / 'instance-1-logs' / 'instance-1-asterisk-logs' / 'full'
+
+    brief_lines = brief_path.read_text().splitlines()
+
+    # Thread LWPs from the crash analysis
+    # Thread 1158 (LWP 834925) - Dial thread holding channel lock
+    # Thread 780 (LWP 816915) - ARI thread holding container lock
+    dial_thread = extract_thread(brief_lines, 834925)
+    ari_thread = extract_thread(brief_lines, 816915)
+
+    output = []
+    output.append('# Sanitized coredump excerpts for upstream bug report')
+    output.append('')
+
+    # Endpoint set_var evidence
+    output.append('## Evidence of endpoint set_var configuration')
+    output.append('')
+    output.append(
+        'The stack trace shows `PJSIP_HEADER(add,X-CUSTOMER-ID)` being called from'
+    )
+    output.append(
+        '`chan_pjsip_new()` via the endpoint `channel_vars` loop (set_var config):'
+    )
+    output.append('```')
+    for line in extract_endpoint_config_evidence(brief_lines, 834925):
+        output.append(line)
+    output.append('```')
+    output.append('')
+
+    # Deadlock threads
+    output.append(
+        '## Thread A: Dial / chan_pjsip_new — holds channel lock, waiting on serializer'
+    )
+    output.append('```')
+    for line in dial_thread:
+        output.append(anonymize_line(line))
+    output.append('```')
+    output.append('')
+    output.append(
+        '## Thread B: ARI GET channel variable — holds container lock, '
+        'waiting on channel lock'
+    )
+    output.append('```')
+    for line in ari_thread:
+        output.append(anonymize_line(line))
+    output.append('```')
+    output.append('')
+
+    # Log excerpt
+    if log_path.exists():
+        output.append('## Asterisk log around crash time')
+        output.append('```')
+        for line in extract_log_around_crash(log_path):
+            output.append(line)
+        output.append('```')
+        output.append('')
+
+    # System state
+    output.append('## System state at crash')
+    output.append('```')
+    output.append(extract_system_summary(info_path))
+    output.append('```')
+
+    result = '\n'.join(output)
+    out_path = base / 'sanitized-coredump-excerpts.md'
+    out_path.write_text(result + '\n')
+    print(f'Written to {out_path}')
+
+    # Anonymized info.txt (full structure preserved)
+    info_lines = info_path.read_text().splitlines()
+    anon_info = '\n'.join(anonymize_line(ln) for ln in info_lines)
+    anon_info_path = base / 'sanitized-info.txt'
+    anon_info_path.write_text(anon_info + '\n')
+    print(f'Written to {anon_info_path}')
+
+
+if __name__ == '__main__':
+    main()

--- a/sanitize-coredump/sanitize-coredump.py
+++ b/sanitize-coredump/sanitize-coredump.py
@@ -74,6 +74,7 @@ def anonymize_line(line: str) -> str:
     line = HEADER_VAL.sub(r'\1"XXXXXXXX"', line)
     line = VALUE_NUMERIC.sub(r'\1"XXXXXXXX"', line)
     line = CALLERID_ARG.sub(r'\1"+XXXXXXXXXXXX"', line)
+    line = SIP_DISPLAY_NAME.sub('"REDACTED NAME"', line)
     line = PJSIP_ENDPOINT.sub(r'\1ENDPOINT\3', line)
     line = MWI_SUB.sub(r'\1XXXXXXX@XXXXX-XXXXX', line)
     line = CTX_ID.sub('ctx-IDXXXXXXXX-', line)

--- a/sanitize-coredump/sanitize-coredump.py
+++ b/sanitize-coredump/sanitize-coredump.py
@@ -138,7 +138,9 @@ class Sanitizer:
             # per-trunk id are customer-correlating, so token the whole name.
             # Runs before the brand-literal rule so the slug is captured here.
             (
-                re.compile(r'[A-Za-z0-9]+_trunk_[0-9a-f](?:[0-9a-f-]*[0-9a-f])?'),
+                # require >=8 hex for the id so non-id names like
+                # default_trunk_config are not mangled.
+                re.compile(r'[A-Za-z0-9]+_trunk_[0-9a-f]{8}[0-9a-f-]*'),
                 lambda m: tok('TRUNK', m.group(0)),
             ),
             (

--- a/sanitize-coredump/test_sanitize_coredump.py
+++ b/sanitize-coredump/test_sanitize_coredump.py
@@ -72,6 +72,16 @@ REDACTION_CASES = [
         id='bridge uuid',
     ),
     pytest.param(
+        'ref 0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4 seen',
+        '0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4',
+        id='truncated trunk uuid (9-hex tail)',
+    ),
+    pytest.param(
+        'branch=z9hG4bKPj0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4678;alias',
+        '0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4678',
+        id='uuid glued to SIP Via branch prefix',
+    ),
+    pytest.param(
         'contact sip:user123@1.2.3.4:5060;ob', 'user123', id='sip contact uri'
     ),
     pytest.param('peer 8.8.8.8 reachable', '8.8.8.8', id='public ip'),
@@ -91,6 +101,16 @@ def test_private_ip_is_preserved():
 
 def test_loopback_ip_is_preserved():
     assert '127.0.0.1' in anonymize_line('bound to 127.0.0.1:5060')
+
+
+def test_trunk_name_fully_redacted():
+    # real trunk ids carry a non-standard UUID the UUID rule misses, so the
+    # dedicated trunk rule must capture the whole <slug>_trunk_<id> name.
+    out = anonymize_line(
+        'PJSIP/customer_trunk_1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5-00000bc0 up'
+    )
+    assert 'customer_trunk' not in out
+    assert '1a2b3c4d' not in out
 
 
 # --- pseudonymization mechanics ---
@@ -142,6 +162,13 @@ def test_config_domain_is_redacted():
     assert 'customer.com' not in out
 
 
+def test_config_domain_redacted_even_when_gdb_truncated():
+    sanitizer = Sanitizer(domains=('instance1.voip3.customer.com',))
+    assert 'voip3' not in sanitizer.line('aor user@instance1.voip3.bo"..., payload')
+    # gdb may cut even shorter, mid-second-label
+    assert 'instance1' not in sanitizer.line('<sip:abc@instance1.v"..., payload')
+
+
 def test_config_header_value_is_redacted():
     out = Sanitizer(headers=('X-TENANT-NAME',)).line(
         '"PJSIP_HEADER(add,X-TENANT-NAME)", value=0x7f001234 "AcmeCorp"'
@@ -160,6 +187,15 @@ def test_national_phone_redacted_when_country_configured():
 def test_cli_filter_sanitizes(tmp_path, capsys):
     src = tmp_path / 'in.txt'
     src.write_text('peer 8.8.8.8 reachable\n')
+    main(['--structural-only', 'filter', str(src)])
+    out = capsys.readouterr().out
+    assert '8.8.8.8' not in out
+    assert 'IP_1' in out
+
+
+def test_cli_filter_handles_non_utf8_bytes(tmp_path, capsys):
+    src = tmp_path / 'bin.txt'
+    src.write_bytes(b'peer 8.8.8.8 \x97 raw byte\n')
     main(['--structural-only', 'filter', str(src)])
     out = capsys.readouterr().out
     assert '8.8.8.8' not in out

--- a/sanitize-coredump/test_sanitize_coredump.py
+++ b/sanitize-coredump/test_sanitize_coredump.py
@@ -1,0 +1,94 @@
+"""Tests proving each redaction pattern in sanitize-coredump.py actually fires.
+
+For a sanitizer the cardinal failure is the false negative (a leak), so every
+pattern gets a case asserting the sensitive token does not survive in the
+output. The module filename has a dash, so it is loaded via importlib.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = Path(__file__).parent / 'sanitize-coredump.py'
+_spec = importlib.util.spec_from_file_location('sanitize_coredump', _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+anonymize_line = _module.anonymize_line
+
+
+# pytest.param(input line, substring that MUST NOT survive, id=pattern name)
+REDACTION_CASES = [
+    pytest.param('caller +33612345678 dialed', '+33612345678', id='phone E164'),
+    pytest.param(
+        'from 0612345678 here',
+        '0612345678',
+        id='phone national',
+        marks=pytest.mark.xfail(
+            reason='PHONE_NATIONAL is FR-specific; needs per-country handling '
+            '(see GENERALIZATION-PLAN.md)',
+            strict=True,
+        ),
+    ),
+    pytest.param(
+        'endpoint=customer_trunk_ab12cd34-ef', 'customer_trunk', id='customer trunk'
+    ),
+    pytest.param(
+        'host instance1.voip2.customer.com up', 'customer.com', id='customer host'
+    ),
+    pytest.param(
+        '"PJSIP_HEADER(add,X-CUSTOMER-ID)", value=0x7f001234 "9876543"',
+        '9876543',
+        id='customer-id header value',
+    ),
+    pytest.param(
+        'data=0x55 "add", value=0x66 "789012"', '789012', id='header add value'
+    ),
+    pytest.param('foo value=0x55 "1234567" bar', '1234567', id='bare numeric value'),
+    pytest.param('callerid=0x7f0012 "+33612345678"', '+33612345678', id='callerid arg'),
+    pytest.param('From: "John Smith" <sip:...>', 'John Smith', id='sip display name'),
+    pytest.param('channel PJSIP/ABcD1234@ctx active', 'ABcD1234', id='pjsip endpoint'),
+    pytest.param('PJSIP/ABcD1234-0000abcd hung up', 'ABcD1234', id='pjsip channel'),
+    pytest.param(
+        'Local/ABcD1234@default-0001', 'ABcD1234', id='local channel endpoint'
+    ),
+    pytest.param(
+        'pjsip/options/ABcD1234-00000040', 'ABcD1234', id='taskprocessor endpoint'
+    ),
+    pytest.param('dial_mobile,join,ABcD1234', 'ABcD1234', id='dial_mobile endpoint'),
+    pytest.param(
+        'stasis/p:mwi:all/1001@ctx-ID3-internal-aa-bb',
+        '1001@ctx',
+        id='mwi subscription',
+    ),
+    pytest.param('in ctx-ID42-internal', 'ctx-ID42', id='context tenant id'),
+    pytest.param('wazo-app-ab12cd34-ef56 started', 'ab12cd34', id='wazo app uuid'),
+    pytest.param('wazo-dial-mobile-ab12cd34-ef56', 'ab12cd34', id='wazo dial mobile'),
+    pytest.param('grp-ID5-ab12cd34-ef56', 'ab12cd34', id='group id'),
+    pytest.param(
+        'bridge 12345678-1234-1234-1234-123456789abc',
+        '12345678-1234-1234-1234-123456789abc',
+        id='bridge uuid',
+    ),
+    pytest.param(
+        'contact sip:user123@1.2.3.4:5060;ob', 'user123', id='sip contact uri'
+    ),
+    pytest.param('peer 8.8.8.8 reachable', '8.8.8.8', id='public ip'),
+]
+
+
+@pytest.mark.parametrize('line,forbidden', REDACTION_CASES)
+def test_pattern_redacts_sensitive_token(line, forbidden):
+    assert forbidden not in anonymize_line(line)
+
+
+def test_private_ip_is_preserved():
+    line = 'internal peer 10.42.0.1 and 192.168.1.5'
+    result = anonymize_line(line)
+    assert '10.42.0.1' in result
+    assert '192.168.1.5' in result
+
+
+def test_loopback_ip_is_preserved():
+    assert '127.0.0.1' in anonymize_line('bound to 127.0.0.1:5060')

--- a/sanitize-coredump/test_sanitize_coredump.py
+++ b/sanitize-coredump/test_sanitize_coredump.py
@@ -51,6 +51,11 @@ REDACTION_CASES = [
     pytest.param('channel PJSIP/ABcD1234@ctx active', 'ABcD1234', id='pjsip endpoint'),
     pytest.param('PJSIP/ABcD1234-0000abcd hung up', 'ABcD1234', id='pjsip channel'),
     pytest.param(
+        'dialstring PJSIP/ysy7AakU&PJSIP/other',
+        'ysy7AakU',
+        id='pjsip endpoint before &',
+    ),
+    pytest.param(
         'Local/ABcD1234@default-0001', 'ABcD1234', id='local channel endpoint'
     ),
     pytest.param(
@@ -132,7 +137,7 @@ def test_distinct_values_get_distinct_tokens():
 
 def test_sanitization_does_not_rematch_generated_tokens():
     line = (
-        'PJSIP/ABcD1234-0000abcd dial_mobile,join,EfGh5678 '
+        'PJSIP/ABcD1234-0000abcd&PJSIP/ZyXw9876 dial_mobile,join,EfGh5678 '
         'sip:user123@1.2.3.4:5060 12345678-1234-1234-1234-123456789abc '
         'ctx-ID42 wazo-app-ab12cd34-ef56 +33612345678'
     )

--- a/sanitize-coredump/test_sanitize_coredump.py
+++ b/sanitize-coredump/test_sanitize_coredump.py
@@ -118,6 +118,11 @@ def test_trunk_name_fully_redacted():
     assert '1a2b3c4d' not in out
 
 
+def test_trunk_rule_does_not_mangle_non_id_names():
+    # a config-like name (no uuid id) must be left intact, not half-eaten
+    assert anonymize_line('default_trunk_config') == 'default_trunk_config'
+
+
 # --- pseudonymization mechanics ---
 
 

--- a/sanitize-coredump/test_sanitize_coredump.py
+++ b/sanitize-coredump/test_sanitize_coredump.py
@@ -1,4 +1,4 @@
-"""Tests proving each redaction pattern in sanitize-coredump.py actually fires.
+"""Tests for the sanitize-coredump sanitizer.
 
 For a sanitizer the cardinal failure is the false negative (a leak), so every
 pattern gets a case asserting the sensitive token does not survive in the
@@ -6,6 +6,7 @@ output. The module filename has a dash, so it is loaded via importlib.
 """
 
 import importlib.util
+import json
 from pathlib import Path
 
 import pytest
@@ -15,10 +16,15 @@ _spec = importlib.util.spec_from_file_location('sanitize_coredump', _MODULE_PATH
 assert _spec is not None and _spec.loader is not None
 _module = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_module)
+
 anonymize_line = _module.anonymize_line
+Sanitizer = _module.Sanitizer
+main = _module.main
 
 
-# pytest.param(input line, substring that MUST NOT survive, id=pattern name)
+# pytest.param(input line, substring that MUST NOT survive, id=pattern name).
+# Customer-specific literals (brand/domain) are covered separately, since they
+# are config-driven and not part of the default structural ruleset.
 REDACTION_CASES = [
     pytest.param('caller +33612345678 dialed', '+33612345678', id='phone E164'),
     pytest.param(
@@ -26,16 +32,10 @@ REDACTION_CASES = [
         '0612345678',
         id='phone national',
         marks=pytest.mark.xfail(
-            reason='PHONE_NATIONAL is FR-specific; needs per-country handling '
-            '(see GENERALIZATION-PLAN.md)',
+            reason='national numbers need per-country config (phone_country); '
+            'not redacted by default (see README design notes)',
             strict=True,
         ),
-    ),
-    pytest.param(
-        'endpoint=customer_trunk_ab12cd34-ef', 'customer_trunk', id='customer trunk'
-    ),
-    pytest.param(
-        'host instance1.voip2.customer.com up', 'customer.com', id='customer host'
     ),
     pytest.param(
         '"PJSIP_HEADER(add,X-CUSTOMER-ID)", value=0x7f001234 "9876543"',
@@ -84,11 +84,100 @@ def test_pattern_redacts_sensitive_token(line, forbidden):
 
 
 def test_private_ip_is_preserved():
-    line = 'internal peer 10.42.0.1 and 192.168.1.5'
-    result = anonymize_line(line)
+    result = anonymize_line('internal peer 10.42.0.1 and 192.168.1.5')
     assert '10.42.0.1' in result
     assert '192.168.1.5' in result
 
 
 def test_loopback_ip_is_preserved():
     assert '127.0.0.1' in anonymize_line('bound to 127.0.0.1:5060')
+
+
+# --- pseudonymization mechanics ---
+
+
+def test_same_value_gets_same_token_across_lines():
+    sanitizer = Sanitizer()
+    first = sanitizer.line('answered PJSIP/ABcD1234-0000aaaa')
+    second = sanitizer.line('hangup PJSIP/ABcD1234-0000bbbb')
+    assert 'ENDPOINT_1' in first
+    assert 'ENDPOINT_1' in second
+
+
+def test_distinct_values_get_distinct_tokens():
+    out = Sanitizer().line('PJSIP/AAAAAA11@x and PJSIP/BBBBBB22@y')
+    assert 'ENDPOINT_1' in out
+    assert 'ENDPOINT_2' in out
+
+
+def test_sanitization_does_not_rematch_generated_tokens():
+    line = (
+        'PJSIP/ABcD1234-0000abcd dial_mobile,join,EfGh5678 '
+        'sip:user123@1.2.3.4:5060 12345678-1234-1234-1234-123456789abc '
+        'ctx-ID42 wazo-app-ab12cd34-ef56 +33612345678'
+    )
+    once = Sanitizer().line(line)
+    twice = Sanitizer().line(once)
+    assert once == twice
+
+
+def test_mapping_recovers_original_value():
+    sanitizer = Sanitizer()
+    sanitizer.line('channel PJSIP/ABcD1234@ctx')
+    assert sanitizer.pseudo.mapping()['ENDPOINT_1'] == 'ABcD1234'
+
+
+# --- caller-supplied config literals ---
+
+
+def test_config_literal_is_redacted():
+    out = Sanitizer(literals=('customer',)).line('endpoint=customer_trunk_ab12cd34-ef')
+    assert 'customer' not in out
+
+
+def test_config_domain_is_redacted():
+    out = Sanitizer(domains=('instance1.voip2.customer.com',)).line(
+        'host instance1.voip2.customer.com up'
+    )
+    assert 'customer.com' not in out
+
+
+def test_config_header_value_is_redacted():
+    out = Sanitizer(headers=('X-TENANT-NAME',)).line(
+        '"PJSIP_HEADER(add,X-TENANT-NAME)", value=0x7f001234 "AcmeCorp"'
+    )
+    assert 'AcmeCorp' not in out
+
+
+def test_national_phone_redacted_when_country_configured():
+    out = Sanitizer(phone_country='FR').line('from 0612345678 here')
+    assert '0612345678' not in out
+
+
+# --- CLI ---
+
+
+def test_cli_filter_sanitizes(tmp_path, capsys):
+    src = tmp_path / 'in.txt'
+    src.write_text('peer 8.8.8.8 reachable\n')
+    main(['--structural-only', 'filter', str(src)])
+    out = capsys.readouterr().out
+    assert '8.8.8.8' not in out
+    assert 'IP_1' in out
+
+
+def test_cli_warns_without_config(tmp_path, capsys):
+    src = tmp_path / 'in.txt'
+    src.write_text('nothing sensitive\n')
+    main(['filter', str(src)])
+    assert 'WARNING' in capsys.readouterr().err
+
+
+def test_cli_mapping_out_kept_out_of_sanitized_output(tmp_path, capsys):
+    src = tmp_path / 'in.txt'
+    src.write_text('peer 8.8.8.8 reachable\n')
+    mapping_path = tmp_path / 'map.json'
+    main(['--structural-only', '--mapping-out', str(mapping_path), 'filter', str(src)])
+    out = capsys.readouterr().out
+    assert '8.8.8.8' not in out
+    assert '8.8.8.8' in json.loads(mapping_path.read_text()).values()


### PR DESCRIPTION
- **feat: add sanitize-coredump incident template**
- **feat(sanitize-coredump): bug fix and tests**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is privacy-critical tooling where missed redactions could leak customer PII in public reports; mitigated by broad pattern coverage, explicit config warnings, and leak-oriented tests, but operational misuse (no `--config`) remains a documented gap.
> 
> **Overview**
> Adds a new **`sanitize-coredump`** Python utility (stdlib only) for scrubbing `ast_coredumper` output and Asterisk logs before upstream/public bug reports. The earlier incident-specific report builder is **removed** in favor of this generalized tool (prior work remains in git history).
> 
> Redaction combines an **always-on structural ruleset** (PJSIP endpoints, Wazo trunk/tenant/UUID patterns, E.164 phones, public IPs, SIP contacts, gdb-style `callerid`/`value=` fields, etc.) with **optional JSON `--config`** literals (brands, domains with gdb-truncation matching, custom PJSIP header values, per-country national numbers, custom regex). Values become **stable counter tokens** (`ENDPOINT_1`, …); the reverse map is written only to **`--mapping-out`**. Running without customer literals triggers a **stderr warning** unless **`--structural-only`** is set.
> 
> The CLI exposes **`filter`** (stdin/files), **`thread`** (LWP backtraces from brief.txt), **`log`** (lines around a regex marker), and **`summary`** (sanitized taskprocessor/channel rollup from info.txt). Input uses UTF-8 with replacement for bad bytes.
> 
> **`test_sanitize_coredump.py`** parametrizes leak checks per pattern, plus token consistency, idempotency, config-driven redaction, trunk/UUID edge cases, and CLI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2394e01f0a7bedfea1899a85d1654171439413d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->