### PR TITLE
sanitize coredump

### DIFF
--- a/sanitize-coredump/GENERALIZATION-PLAN.md
+++ b/sanitize-coredump/GENERALIZATION-PLAN.md
@@ -1,0 +1,101 @@
+# sanitize-coredump — generalization plan
+
+`sanitize-coredump.py` is currently an incident-specific template (the
+2026-02-04 bonline deadlock). This document captures how to turn its reusable
+core into a general-purpose sanitizer, to be implemented later. It is the
+design record only — no code here.
+
+## Guiding principle
+
+For a sanitizer the cardinal failure is the **false negative (a leak)**, not
+the false positive — publishing sanitized output is irreversible. Therefore:
+
+- Bias generic patterns toward **over**-redaction. Over-redacting hurts
+  readability (recoverable); under-redacting leaks (fatal).
+- **Every pattern needs a test proving it fires** on representative input.
+  Tests are the safety property, not DoD box-ticking. A redaction that looks
+  present but silently never runs is the worst case — exactly the
+  `SIP_DISPLAY_NAME` dead-code bug already fixed in this codebase.
+- Any reverse-mapping / de-anonymization data must stay **out of published
+  output by construction**.
+
+## Decomposition
+
+The script conflates two concerns on different reuse axes:
+
+- **(A) Line sanitization** — `anonymize_line` + the pattern set. *Reusable.*
+  This becomes the tool.
+- **(B) Incident report extraction** — the deadlock narrative, frame #7–10
+  picking, the `res_freeze_check` marker, specific thread LWPs, hardcoded
+  dump paths. *Inherently per-incident.* Keep this out of the shared tool;
+  leave it as a documented template or a throwaway per-incident script.
+
+## Pattern buckets
+
+### Customer-specific — must come from config, cannot be inferred
+
+- `CUSTOMER_TRUNK` (`bonline_trunk_*`)
+- `CUSTOMER_HOST` (`instance*.voip*.bonline.com`)
+- `CUSTOMER_ID_VAL` / `HEADER_VAL` (the `X-CUSTOMER-ID` header)
+
+Shape-based patterns structurally cannot know a brand string, tenant slug, or
+vanity domain. The backbone of the generalized tool is therefore:
+**built-in structural ruleset + mandatory caller-supplied literals**
+(brand name, domain(s), tenant id(s), custom header names) redacted everywhere.
+
+### Incident-specific — drop from the shared tool
+
+- hardcoded `prefix` timestamp, thread LWPs, frame-range selection
+- `res_freeze_check ... failed to acquire` log marker
+- hardcoded `instance-1-logs/.../full` path
+- the Thread A / Thread B report structure
+
+At most these become CLI parameters (`--extract-thread LWP`,
+`--context-marker REGEX --before/--after`), not baked-in logic.
+
+### Generic / reusable — the built-in default ruleset
+
+- `PUBLIC_IP` (keep RFC1918 / loopback / TEST-NET exclusions), `SIP_CONTACT`,
+  `BRIDGE_UUID`, `PHONE_E164`
+- Wazo/Asterisk structural identifiers: `WAZO_APP`, `WAZO_DIAL_MOBILE`,
+  `DIAL_MOBILE`, `MWI_SUB`, `GRP_ID`, `CTX_ID`, and the endpoint/channel
+  token patterns (`PJSIP_*`, `TP_ENDPOINT`, `LOCAL_CHAN_ENDPOINT`)
+- the `[A-Za-z0-9]{6,10}` endpoint heuristic is acceptable here: it is
+  anchored to channel-name contexts and errs toward redacting
+- `extract_thread` and `extract_system_summary` are generic and worth keeping
+
+## Open design items
+
+### Phone numbers need context-aware / per-country handling
+
+`PHONE_NATIONAL` is FR-shaped and currently misses canonical 10-digit national
+numbers (tracked by an `xfail` test). A single national regex is **not**
+generic — number plans differ per country (length, leading digits, trunk
+prefix). Options to evaluate:
+
+- per-country pattern set selectable via config (`PHONE_NATIONAL_FR`,
+  `PHONE_NATIONAL_UK`, ...), and/or
+- a context-aware approach keying on SIP/dialplan context rather than the bare
+  digit shape, and/or
+- a vetted library (e.g. `phonenumbers`) for detection.
+
+Until resolved, rely on `PHONE_E164` plus the `callerid`/`value=` context
+patterns; do not assume bare national numbers are caught.
+
+### Consistent pseudonymization (preserve correlation)
+
+Blanket `XXXX` destroys the correlation an analyst needs (e.g. "the same
+endpoint appears in Thread A and Thread B"). Replace with stable per-token
+placeholders so structure survives while identity is removed.
+
+- Use **counter-based** tokens (`ENDPOINT_1`, `TRUNK_2`), **not** salted
+  hashes — a phone-number / numeric-id space is trivially brute-forced, and a
+  leaked salt de-anonymizes everything.
+- Optional private reverse-mapping output, never part of the published file.
+
+### CLI shape
+
+- argparse; act as a stream filter (stdin → stdout) and/or take input files
+- `--config FILE` for the mandatory customer literals + per-country phone set
+- optional extraction helpers: `--extract-thread LWP` (repeatable),
+  `--context-marker REGEX --before N --after N`

--- a/sanitize-coredump/README.md
+++ b/sanitize-coredump/README.md
@@ -39,3 +39,15 @@ logic to the coredump at hand, then run it.
 `instance-1-logs/instance-1-asterisk-logs/full` log).
 
 Requires Python 3 only (standard library).
+
+## Tests
+
+`test_sanitize_coredump.py` asserts that every redaction pattern actually fires
+on representative input — for a sanitizer a silent non-firing rule is a leak.
+Run with `pytest` from this directory.
+
+## Generalizing beyond this incident
+
+The reusable core here is the line sanitizer. Turning it into a general-purpose
+tool (config-driven customer literals, per-country phone handling, consistent
+pseudonymization, a CLI) is designed in [`GENERALIZATION-PLAN.md`](./GENERALIZATION-PLAN.md).

--- a/sanitize-coredump/README.md
+++ b/sanitize-coredump/README.md
@@ -63,8 +63,8 @@ Global options: `--config FILE`, `--mapping-out FILE`, `--structural-only`,
 
 - `literals` / `domains` — strings redacted everywhere (consistent tokens).
 - `headers` — the value of these PJSIP headers (in gdb arg dumps) is redacted.
-- `phone_country` — opt into a per-country national-number pattern (currently
-  `FR`). National numbers are otherwise not caught; see design notes below.
+- `phone_country` — opt into a per-country national-number pattern (`FR`,
+  `UK`). National numbers are otherwise not caught; see design notes below.
 - `patterns` — raw regex→replacement escape hatch, applied last.
 
 ## Tests
@@ -87,6 +87,12 @@ handling. Run with `pytest` from this directory.
   phone-number / numeric-id space is trivially brute-forced and a leaked salt
   would de-anonymize everything. The reverse map stays out of published output
   by construction (only `--mapping-out`).
+- **Robust to real coredump data**: non-UTF-8 bytes are replaced rather than
+  crashing the run; configured `domains` also match gdb-truncated fragments
+  (`instance1.voip3.bo"...`); UUID-shaped ids are matched with a loose tail so
+  non-standard/truncated trunk UUIDs are caught. Verified against a real
+  coredump: brand, hostnames, trunk UUIDs, E.164/national phones and public
+  IPs all redacted (RFC 5737 `192.0.2.0/24` documentation IPs are kept).
 
 The earlier incident-specific report builder (the 20XX-XX-XX customer deadlock
 narrative, frame selection, `res_freeze_check` marker) was intentionally

--- a/sanitize-coredump/README.md
+++ b/sanitize-coredump/README.md
@@ -1,53 +1,93 @@
 # sanitize-coredump
 
-Extract and anonymize relevant Asterisk coredump snippets so they can be shared
-in a public/upstream bug report without leaking customer-identifying data
-(phone numbers, public IPs, hostnames, endpoint/trunk names, tenant UUIDs, ...).
+Sanitize Asterisk coredump / log excerpts so they can be shared in a
+public/upstream bug report without leaking customer-identifying data (phone
+numbers, public IPs, hostnames, endpoint/trunk names, tenant ids, UUIDs, ...).
 
-It reads [`ast_coredumper`](https://github.com/asterisk/asterisk/blob/master/contrib/scripts/ast_coredumper)
-output (`*-brief.txt`, `*-info.txt`) together with the Asterisk `full` log,
-redacts sensitive tokens line-by-line, and writes:
+It works on [`ast_coredumper`](https://github.com/asterisk/asterisk/blob/master/contrib/scripts/ast_coredumper)
+output (`*-brief.txt`, `*-info.txt`) and Asterisk logs.
 
-- `sanitized-coredump-excerpts.md` — a curated report (deadlock threads,
-  endpoint config evidence, log around the crash, system-state summary)
-- `sanitized-info.txt` — the full `info.txt` with the same redaction applied
+## How it redacts
 
-## Status: incident-specific template
+Two layers:
 
-This script was written for a specific incident (the 20XX-XX-XX customer upgrade
-deadlock) and is **not** a general-purpose tool. Several things are hardcoded
-and must be adapted before reuse:
+- a **built-in structural ruleset** for generic Asterisk/Wazo identifiers and
+  PII (endpoints, channels, MWI subscriptions, tenant/group ids, UUIDs, SIP
+  contacts, E.164 phone numbers, public IPs, ...) — always on;
+- **caller-supplied literals** from `--config` (brand names, vanity domains,
+  tenant slugs, custom SIP headers). These cannot be inferred from shape alone,
+  so without a config they are **not** redacted — the tool warns loudly on
+  stderr when run without one (pass `--structural-only` to acknowledge).
 
-- `prefix` — the `core-asterisk-<timestamp>` filename prefix (in `main()`)
-- the thread LWPs of interest (`834925`, `816915`)
-- the crash marker used to locate the log excerpt (`res_freeze_check ...
-  failed to acquire`)
-- customer-specific redaction patterns (`customer_trunk_*`,
-  `instance*.voip*.customer.com`)
-
-Keep it as a starting point: copy it, adjust the patterns and the extraction
-logic to the coredump at hand, then run it.
+Sensitive values are replaced with stable counter-based tokens (`ENDPOINT_1`,
+`UUID_2`, ...) rather than blanked out, so correlation survives sanitization:
+the same endpoint keeps the same token across threads. The reverse
+token→value map (the de-anonymization key) is written **only** to
+`--mapping-out`, never to the sanitized output — keep it private.
 
 ## Usage
 
 ```sh
-./sanitize-coredump.py [DIR]
+# sanitize a file or stdin (stream filter)
+./sanitize-coredump.py --config customer.json filter core-info.txt > clean-info.txt
+cat core-brief.txt | ./sanitize-coredump.py --structural-only filter
+
+# extract & sanitize specific thread backtraces by LWP
+./sanitize-coredump.py --config customer.json thread core-brief.txt --lwp 834925 --lwp 816915
+
+# extract & sanitize log lines around a marker
+./sanitize-coredump.py --config customer.json log full \
+    --marker 'res_freeze_check.*failed to acquire' --before 5 --after 5
+
+# sanitized system-state summary from info.txt
+./sanitize-coredump.py --config customer.json summary core-info.txt
+
+# keep the de-anonymization key for your own later reference
+./sanitize-coredump.py --config customer.json --mapping-out key.json filter core-info.txt
 ```
 
-`DIR` defaults to the current directory and must contain the
-`ast_coredumper` output files (and optionally the
-`instance-1-logs/instance-1-asterisk-logs/full` log).
+Global options: `--config FILE`, `--mapping-out FILE`, `--structural-only`,
+`-o/--output FILE`. Requires Python 3 only (standard library).
 
-Requires Python 3 only (standard library).
+### Config file (JSON)
+
+```json
+{
+  "literals": ["acmecorp"],
+  "domains": ["instance1.voip2.acmecorp.com"],
+  "headers": ["X-CUSTOMER-ID"],
+  "phone_country": "FR",
+  "patterns": [{"pattern": "secret-\\d+", "replacement": "REDACTED"}]
+}
+```
+
+- `literals` / `domains` — strings redacted everywhere (consistent tokens).
+- `headers` — the value of these PJSIP headers (in gdb arg dumps) is redacted.
+- `phone_country` — opt into a per-country national-number pattern (currently
+  `FR`). National numbers are otherwise not caught; see design notes below.
+- `patterns` — raw regex→replacement escape hatch, applied last.
 
 ## Tests
 
 `test_sanitize_coredump.py` asserts that every redaction pattern actually fires
-on representative input — for a sanitizer a silent non-firing rule is a leak.
-Run with `pytest` from this directory.
+on representative input (a silent non-firing rule is a leak), plus token
+consistency/distinctness, idempotency (generated tokens are never re-matched),
+config-literal redaction, and the CLI's config-gate warning and mapping
+handling. Run with `pytest` from this directory.
 
-## Generalizing beyond this incident
+## Design notes & open items
 
-The reusable core here is the line sanitizer. Turning it into a general-purpose
-tool (config-driven customer literals, per-country phone handling, consistent
-pseudonymization, a CLI) is designed in [`GENERALIZATION-PLAN.md`](./GENERALIZATION-PLAN.md).
+- **National phone numbers** are redacted only when `phone_country` is set,
+  because a single national regex is not generic — number plans differ per
+  country (length, leading digits, trunk prefix). E.164 numbers and the
+  `callerid`/`value=` context rules are always covered; do not assume bare
+  national numbers are caught otherwise. Future options: more per-country
+  patterns, context-aware detection, or a vetted library (`phonenumbers`).
+- **Pseudonymization is counter-based, not hashed**, on purpose: a
+  phone-number / numeric-id space is trivially brute-forced and a leaked salt
+  would de-anonymize everything. The reverse map stays out of published output
+  by construction (only `--mapping-out`).
+
+The earlier incident-specific report builder (the 20XX-XX-XX customer deadlock
+narrative, frame selection, `res_freeze_check` marker) was intentionally
+dropped here; it remains in git history (commits `d2dad71` / `f8e7885`).

--- a/sanitize-coredump/README.md
+++ b/sanitize-coredump/README.md
@@ -13,7 +13,8 @@ Two layers:
 
 - a **built-in structural ruleset** for generic Asterisk/Wazo identifiers and
   PII (endpoints, channels, MWI subscriptions, tenant/group ids, UUIDs, SIP
-  contacts, E.164 phone numbers, public IPs, ...) — always on;
+  contacts, E.164 phone numbers, public IPv4/IPv6 addresses, ...) — always on
+  (loopback/private IPv4 and loopback/link-local/ULA IPv6 are preserved);
 - **caller-supplied literals** from `--config` (brand names, vanity domains,
   tenant slugs, custom SIP headers). These cannot be inferred from shape alone,
   so without a config they are **not** redacted — the tool warns loudly on

--- a/sanitize-coredump/README.md
+++ b/sanitize-coredump/README.md
@@ -1,0 +1,41 @@
+# sanitize-coredump
+
+Extract and anonymize relevant Asterisk coredump snippets so they can be shared
+in a public/upstream bug report without leaking customer-identifying data
+(phone numbers, public IPs, hostnames, endpoint/trunk names, tenant UUIDs, ...).
+
+It reads [`ast_coredumper`](https://github.com/asterisk/asterisk/blob/master/contrib/scripts/ast_coredumper)
+output (`*-brief.txt`, `*-info.txt`) together with the Asterisk `full` log,
+redacts sensitive tokens line-by-line, and writes:
+
+- `sanitized-coredump-excerpts.md` — a curated report (deadlock threads,
+  endpoint config evidence, log around the crash, system-state summary)
+- `sanitized-info.txt` — the full `info.txt` with the same redaction applied
+
+## Status: incident-specific template
+
+This script was written for a specific incident (the 20XX-XX-XX customer upgrade
+deadlock) and is **not** a general-purpose tool. Several things are hardcoded
+and must be adapted before reuse:
+
+- `prefix` — the `core-asterisk-<timestamp>` filename prefix (in `main()`)
+- the thread LWPs of interest (`834925`, `816915`)
+- the crash marker used to locate the log excerpt (`res_freeze_check ...
+  failed to acquire`)
+- customer-specific redaction patterns (`customer_trunk_*`,
+  `instance*.voip*.customer.com`)
+
+Keep it as a starting point: copy it, adjust the patterns and the extraction
+logic to the coredump at hand, then run it.
+
+## Usage
+
+```sh
+./sanitize-coredump.py [DIR]
+```
+
+`DIR` defaults to the current directory and must contain the
+`ast_coredumper` output files (and optionally the
+`instance-1-logs/instance-1-asterisk-logs/full` log).
+
+Requires Python 3 only (standard library).

--- a/sanitize-coredump/README.md
+++ b/sanitize-coredump/README.md
@@ -91,9 +91,22 @@ handling. Run with `pytest` from this directory.
 - **Robust to real coredump data**: non-UTF-8 bytes are replaced rather than
   crashing the run; configured `domains` also match gdb-truncated fragments
   (`instance1.voip3.bo"...`); UUID-shaped ids are matched with a loose tail so
-  non-standard/truncated trunk UUIDs are caught. Verified against a real
-  coredump: brand, hostnames, trunk UUIDs, E.164/national phones and public
-  IPs all redacted (RFC 5737 `192.0.2.0/24` documentation IPs are kept).
+  non-standard/truncated trunk UUIDs are caught. Verified against real coredumps
+  from several deployments (RFC 5737 `192.0.2.0/24` documentation IPs are kept).
+- **Endpoint/trunk/context names** are redacted structurally in the standard
+  Asterisk positions — `PJSIP/<ep>`, `pjsip/{options,outsess,outreg}/<ep>`,
+  `Local/<ep>`, `stasis/p:endpoint:PJSIP/<ep>`, `<slug>_trunk_<id>`,
+  `ctx-<tenant>` — and cover names that are hex UUIDs *or* human/business
+  names (e.g. `dstny_trunk_ChapelleTrucksServices`, `ALLIANZ_ANNE_BAILLET_UNYC`,
+  `ctx-CABINETOPH`). Standard Wazo names with underscores (`wazo_wait`,
+  `WAZO_USER`) and C/C++ backtrace symbols (`ast_channel_lock`, `basic_string`)
+  are deliberately **not** matched — underscore-bearing names are only redacted
+  in those anchored contexts, never globally.
+- **Deployment-specific naming** that appears outside the anchored contexts
+  (e.g. an endpoint name after `@` in a dial string, where it shares the
+  position with `@wazo_wait`) cannot be inferred structurally. Redact it with a
+  `--config` `patterns` entry keyed on the deployment's stable marker, e.g.
+  `{"patterns": [{"pattern": "[A-Za-z0-9_]+_UNYC", "replacement": "ENDPOINT"}]}`.
 
 The earlier incident-specific report builder (the 20XX-XX-XX customer deadlock
 narrative, frame selection, `res_freeze_check` marker) was intentionally

--- a/sanitize-coredump/sanitize-coredump.py
+++ b/sanitize-coredump/sanitize-coredump.py
@@ -163,7 +163,7 @@ class Sanitizer:
         rules: list[Rule] = []
 
         # --- caller-supplied domains and headers (specific contexts, run early)
-        for domain in sorted(set(domains), key=len, reverse=True):
+        for domain in sorted(filter(None, set(domains)), key=len, reverse=True):
             rules.append(
                 (
                     re.compile(_truncatable_domain_regex(domain)),
@@ -332,13 +332,13 @@ class Sanitizer:
         # --- caller-supplied brand literals (generic substrings, run late so
         # they only catch standalone mentions, not parts of compound names
         # already tokenized above; longest first to avoid partial shadowing)
-        for literal in sorted(set(literals), key=len, reverse=True):
+        for literal in sorted(filter(None, set(literals)), key=len, reverse=True):
             rules.append(
                 (re.compile(re.escape(literal)), lambda m: tok('LITERAL', m.group(0)))
             )
 
         # --- caller-supplied raw regex escape hatch (applied last) ---
-        rules += [(re.compile(pat), repl) for pat, repl in extra_patterns]
+        rules += [(re.compile(pat), repl) for pat, repl in extra_patterns if pat]
 
         return rules
 

--- a/sanitize-coredump/sanitize-coredump.py
+++ b/sanitize-coredump/sanitize-coredump.py
@@ -44,6 +44,28 @@ NATIONAL_PHONE_PATTERNS = {
     'UK': re.compile(r'\b0\d{9,10}\b'),
 }
 
+# IPv6 matcher. Only "strong" forms are matched (full 8 groups, a hex group
+# before '::', or IPv4-mapped/embedded) so bare 'ns::Sym' tokens common in gdb
+# backtraces are not mangled; the digit requirement (enforced in the
+# replacement) further rules out pure-letter symbols like 'cafe::babe'.
+_H6 = r'[0-9A-Fa-f]{1,4}'
+_OCTET = r'(?:25[0-5]|2[0-4][0-9]|1?[0-9]?[0-9])'
+_IPV4 = rf'(?:{_OCTET}\.){{3}}{_OCTET}'
+IPV6 = re.compile(
+    r'(?<![0-9A-Fa-f:.])(?:'
+    rf'(?:{_H6}:){{7}}{_H6}'  # full 1:2:3:4:5:6:7:8
+    rf'|(?:{_H6}:){{1,7}}:'  # 1:: ... 1:2:3:4:5:6:7::
+    rf'|(?:{_H6}:){{1,6}}:{_H6}'  # 1::8
+    rf'|(?:{_H6}:){{1,5}}(?::{_H6}){{1,2}}'
+    rf'|(?:{_H6}:){{1,4}}(?::{_H6}){{1,3}}'
+    rf'|(?:{_H6}:){{1,3}}(?::{_H6}){{1,4}}'
+    rf'|(?:{_H6}:){{1,2}}(?::{_H6}){{1,5}}'
+    rf'|{_H6}:(?::{_H6}){{1,6}}'
+    rf'|(?:{_H6}:){{1,4}}:{_IPV4}'  # IPv4-embedded
+    rf'|::(?:[fF]{{4}}(?::0{{1,4}})?:)?{_IPV4}'  # IPv4-mapped ::ffff:1.2.3.4
+    r')(?![0-9A-Fa-f:.])'
+)
+
 
 def _truncatable_domain_regex(domain: str) -> str:
     """Regex matching ``domain`` or any gdb-truncated prefix of it.
@@ -213,8 +235,18 @@ class Sanitizer:
                 )
             rules.append((national, lambda m: tok('PHONE', m.group(0))))
 
+        def ipv6_repl(m: re.Match) -> str:
+            addr = m.group(0)
+            if not any(c.isdigit() for c in addr):
+                return addr  # no digit: almost certainly a symbol, not an address
+            low = addr.lower()
+            if low == '::1' or low.startswith(('fe8', 'fe9', 'fea', 'feb', 'fc', 'fd')):
+                return addr  # loopback / link-local / ULA: not customer-identifying
+            return tok('IP', addr)
+
         rules += [
             (re.compile(r'\+\d{10,15}'), lambda m: tok('PHONE', m.group(0))),
+            (IPV6, ipv6_repl),
             (
                 re.compile(
                     r'\b(?!10\.)(?!172\.(?:1[6-9]|2\d|3[01])\.)(?!192\.168\.)'

--- a/sanitize-coredump/sanitize-coredump.py
+++ b/sanitize-coredump/sanitize-coredump.py
@@ -154,8 +154,11 @@ class Sanitizer:
                 lambda m: m.group(1) + '"' + tok('CUSTID', m.group(2)) + '"',
             ),
             (
-                re.compile(r'(PJSIP/)([A-Za-z0-9]{6,10})(@|/|-)'),
-                lambda m: m.group(1) + tok('ENDPOINT', m.group(2)) + m.group(3),
+                # endpoint terminates at any non-word char (@ / - & , ; space
+                # ...); excluding '_' keeps generated TAG_n tokens from
+                # re-matching (idempotency).
+                re.compile(r'(PJSIP/)([A-Za-z0-9]{6,10})(?![A-Za-z0-9_])'),
+                lambda m: m.group(1) + tok('ENDPOINT', m.group(2)),
             ),
             (
                 re.compile(r'(stasis/p:mwi:all/)(\d+@\S+)'),

--- a/sanitize-coredump/sanitize-coredump.py
+++ b/sanitize-coredump/sanitize-coredump.py
@@ -296,8 +296,12 @@ class Sanitizer:
 
         def ipv6_repl(m: re.Match) -> str:
             addr = m.group(0)
-            if not any(c.isdigit() for c in addr):
-                return addr  # no digit: almost certainly a symbol, not an address
+            groups = re.split(r':+', addr.strip(':'))
+            if not any(c.isdigit() for c in addr) and len(groups) <= 2:
+                # short letter-only match (e.g. cafe::babe): a C++ ns::Sym
+                # token, not an address. Longer letter-only matches are kept
+                # below, since real addresses can be written in pure hex.
+                return addr
             low = addr.lower()
             if low == '::1' or low.startswith(('fe8', 'fe9', 'fea', 'feb', 'fc', 'fd')):
                 return addr  # loopback / link-local / ULA: not customer-identifying

--- a/sanitize-coredump/sanitize-coredump.py
+++ b/sanitize-coredump/sanitize-coredump.py
@@ -1,102 +1,225 @@
 #!/usr/bin/env python3
-"""Extract and anonymize relevant coredump snippets for upstream bug report.
+"""Sanitize Asterisk coredump / log excerpts for public sharing.
 
-Reads ast_coredumper output files (brief.txt, info.txt) and Asterisk logs,
-then produces sanitized excerpts suitable for public sharing.
+Redacts PII and customer-identifying tokens (phone numbers, public IPs,
+hostnames, endpoint/trunk names, tenant ids, UUIDs, ...) from ast_coredumper
+output and Asterisk logs before they go into an upstream/public bug report.
+
+Two layers of redaction:
+
+- a built-in structural ruleset for generic Asterisk/Wazo identifiers and PII
+  (always on);
+- caller-supplied literals from --config (brand names, vanity domains, tenant
+  ids, custom SIP headers) which CANNOT be inferred from shape alone.
+
+Sensitive values are replaced with stable counter-based tokens (ENDPOINT_1,
+UUID_2, ...) so that correlation survives sanitization — the same endpoint
+keeps the same token across threads — while identity is removed. The reverse
+mapping is the de-anonymization key; it is written only to --mapping-out,
+never to the sanitized output.
+
+The original incident-specific report builder (deadlock narrative, frame
+selection, res_freeze_check marker) was intentionally dropped in this
+generalization; it remains in git history (commits d2dad71 / f8e7885).
 """
 
+import argparse
+import json
 import re
 import sys
 from pathlib import Path
+from typing import Callable
 
-# Patterns to redact
-PHONE_E164 = re.compile(r'\+\d{10,15}')
-PHONE_NATIONAL = re.compile(r'\b0[1-9]\d{9,10}\b')
-# Customer-identifying trunk/endpoint names: customer_trunk_<uuid>
-CUSTOMER_TRUNK = re.compile(r'customer_trunk_[0-9a-f-]+')
-# Short endpoint tokens (8-char alphanum used as PJSIP endpoint names)
-# Only match when in PJSIP context to avoid false positives
-PJSIP_ENDPOINT = re.compile(r'(PJSIP/)([A-Za-z0-9]{6,10})(@|/|-)')
-# Customer ID values (numeric, in X-CUSTOMER-ID context)
-CUSTOMER_ID_VAL = re.compile(
-    r'("PJSIP_HEADER\(add,X-CUSTOMER-ID\)", value=0x[0-9a-f]+ )"[0-9]+"'
-)
-HEADER_VAL = re.compile(r'(data=0x[0-9a-f]+ "add", value=0x[0-9a-f]+ )"[0-9]+"')
-# Bare numeric string values (customer IDs etc.) in value= arguments
-VALUE_NUMERIC = re.compile(r'(value=[^ ]+ )"(\d{6,})"')
-# Hostname
-CUSTOMER_HOST = re.compile(r'instance\d+\.voip\d+\.customer\.com')
-# Public IPs (not RFC1918, not loopback, not documentation range)
-PUBLIC_IP = re.compile(
-    r'\b(?!10\.)(?!172\.(?:1[6-9]|2\d|3[01])\.)(?!192\.168\.)(?!127\.)(?!192\.0\.2\.)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b'
-)
-# Personal names in SIP From display names won't appear in brief.txt thread excerpts
-# but guard against them anyway
-SIP_DISPLAY_NAME = re.compile(r'"([A-Z][a-z]+ [A-Z][a-z]+)"')
-# callerid in ast_spawn_extension
-CALLERID_ARG = re.compile(r'(callerid=0x[0-9a-f]+ )"\+?\d{10,15}"')
-# Context names with tenant IDs
-CTX_ID = re.compile(r'ctx-ID\d+-')
-# Wazo app UUIDs
-WAZO_APP = re.compile(r'wazo-app-[0-9a-f-]+')
-# Endpoint tokens in taskprocessor/channel names (8-char alphanum)
-# e.g. pjsip/options/ABcD1234-00000040, pjsip/outsess/ABcD1234-00000040
-TP_ENDPOINT = re.compile(r'(pjsip/(?:options|outsess)/)([A-Za-z0-9]{6,10})(-)')
-# stasis/p:mwi:all/<ext>@<context>-<tp_hex>
-# Formats: <num>@ctx-ID<num>-internal-<hex>-<hex>-<tp>
-#          <num>@default-internal-<token>-<tp>
-#          <num>@ctx-<token>-internal-<hex>-<hex>-<tp>
-MWI_SUB = re.compile(r'(stasis/p:mwi:all/)\d+@\S+')
-# Local channel with endpoint token: Local/<token>@context
-LOCAL_CHAN_ENDPOINT = re.compile(r'(Local/)[A-Za-z0-9]{6,10}(@)')
-# PJSIP channel names: PJSIP/<endpoint>-<hex>
-PJSIP_CHAN = re.compile(r'(PJSIP/)([A-Za-z0-9]{6,10})(-[0-9a-f]+)')
-# Bridge UUIDs (standalone UUID pattern in bridge/channel table)
-BRIDGE_UUID = re.compile(
-    r'\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b'
-)
-# grp-ID<num>-<uuid> group identifiers
-GRP_ID = re.compile(r'grp-ID\d+-[0-9a-f-]+')
-# dial_mobile data: dial_mobile,<action>,<endpoint>
-DIAL_MOBILE = re.compile(r'(dial_mobile,\w+,)[A-Za-z0-9]{6,10}')
-# Dial string with SIP contact URI: sip:<user>@<ip>:<port>
-SIP_CONTACT = re.compile(r'sip:[A-Za-z0-9]+@[\d.]+:\d+[^)\s]*')
-# wazo-dial-mobile-<uuid>
-WAZO_DIAL_MOBILE = re.compile(r'wazo-dial-mobile-[0-9a-f-]+')
+# A redaction rule: a compiled pattern and a replacement (str or match->str).
+Replacement = Callable[[re.Match], str] | str
+Rule = tuple[re.Pattern, Replacement]
+
+# Per-country national number plans (opt-in via config phone_country). A single
+# national regex is not generic; bare national numbers are NOT redacted unless a
+# country is configured. Rely otherwise on PHONE_E164 and the callerid/value=
+# context rules.
+NATIONAL_PHONE_PATTERNS = {
+    'FR': re.compile(r'\b0[1-9]\d{8}\b'),
+}
 
 
-def anonymize_line(line: str) -> str:
-    line = CUSTOMER_TRUNK.sub(
-        'example_trunk_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', line
-    )
-    line = CUSTOMER_HOST.sub('sip.example.com', line)
-    line = CUSTOMER_ID_VAL.sub(r'\1"XXXXXXXX"', line)
-    line = HEADER_VAL.sub(r'\1"XXXXXXXX"', line)
-    line = VALUE_NUMERIC.sub(r'\1"XXXXXXXX"', line)
-    line = CALLERID_ARG.sub(r'\1"+XXXXXXXXXXXX"', line)
-    line = SIP_DISPLAY_NAME.sub('"REDACTED NAME"', line)
-    line = PJSIP_ENDPOINT.sub(r'\1ENDPOINT\3', line)
-    line = MWI_SUB.sub(r'\1XXXXXXX@XXXXX-XXXXX', line)
-    line = CTX_ID.sub('ctx-IDXXXXXXXX-', line)
-    line = WAZO_APP.sub('wazo-app-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', line)
-    line = TP_ENDPOINT.sub(r'\1ENDPOINT\3', line)
-    line = LOCAL_CHAN_ENDPOINT.sub(r'\1ENDPOINT\2', line)
-    line = PJSIP_CHAN.sub(r'\1ENDPOINT\3', line)
-    line = GRP_ID.sub('grp-IDXXXXXXXX-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', line)
-    line = DIAL_MOBILE.sub(r'\1ENDPOINT', line)
-    line = SIP_CONTACT.sub('sip:XXXXX@X.X.X.X:XXXXX', line)
-    line = WAZO_DIAL_MOBILE.sub(
-        'wazo-dial-mobile-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', line
-    )
-    line = PHONE_E164.sub('+XXXXXXXXXXXX', line)
-    line = PHONE_NATIONAL.sub('0XXXXXXXXXX', line)
-    line = PUBLIC_IP.sub('X.X.X.X', line)
-    line = BRIDGE_UUID.sub('XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', line)
-    return line
+class Pseudonymizer:
+    """Maps each distinct sensitive value to a stable counter-based token.
+
+    Counter-based (not hashed) on purpose: a phone-number / numeric-id space is
+    trivially brute-forced, and a leaked salt would de-anonymize everything.
+    """
+
+    def __init__(self) -> None:
+        self._counters: dict[str, int] = {}
+        self._tokens: dict[tuple[str, str], str] = {}
+
+    def token(self, tag: str, value: str) -> str:
+        key = (tag, value)
+        token = self._tokens.get(key)
+        if token is None:
+            count = self._counters.get(tag, 0) + 1
+            self._counters[tag] = count
+            token = f'{tag}_{count}'
+            self._tokens[key] = token
+        return token
+
+    def mapping(self) -> dict[str, str]:
+        """Reverse map token -> original value (the de-anonymization key)."""
+        return {token: value for (_, value), token in self._tokens.items()}
+
+
+class Sanitizer:
+    def __init__(
+        self,
+        pseudo: Pseudonymizer | None = None,
+        literals: tuple[str, ...] = (),
+        domains: tuple[str, ...] = (),
+        headers: tuple[str, ...] = (),
+        extra_patterns: tuple[tuple[str, str], ...] = (),
+        phone_country: str | None = None,
+    ) -> None:
+        self.pseudo = pseudo or Pseudonymizer()
+        self._rules = self._build_rules(
+            literals, domains, headers, extra_patterns, phone_country
+        )
+
+    def _build_rules(
+        self,
+        literals: tuple[str, ...],
+        domains: tuple[str, ...],
+        headers: tuple[str, ...],
+        extra_patterns: tuple[tuple[str, str], ...],
+        phone_country: str | None,
+    ) -> list[Rule]:
+        tok = self.pseudo.token
+        rules: list[Rule] = []
+
+        # --- caller-supplied literals (longest first to avoid partial shadowing)
+        for domain in sorted(set(domains), key=len, reverse=True):
+            rules.append(
+                (re.compile(re.escape(domain)), lambda m: tok('HOST', m.group(0)))
+            )
+        for literal in sorted(set(literals), key=len, reverse=True):
+            rules.append(
+                (re.compile(re.escape(literal)), lambda m: tok('LITERAL', m.group(0)))
+            )
+        for header in headers:
+            rx = re.compile(
+                r'("PJSIP_HEADER\([^,]+,'
+                + re.escape(header)
+                + r'\)", value=0x[0-9a-f]+ )"([^"]*)"'
+            )
+            rules.append(
+                (rx, lambda m: m.group(1) + '"' + tok('HEADERVAL', m.group(2)) + '"')
+            )
+
+        # --- built-in structural ruleset (order is load-bearing) ---
+        rules += [
+            (
+                re.compile(r'"([A-Z][a-z]+ [A-Z][a-z]+)"'),
+                lambda m: '"' + tok('NAME', m.group(1)) + '"',
+            ),
+            (
+                re.compile(r'(callerid=0x[0-9a-f]+ )"\+?(\d{10,15})"'),
+                lambda m: m.group(1) + '"' + tok('PHONE', m.group(2)) + '"',
+            ),
+            (
+                re.compile(r'(value=[^ ]+ )"(\d{6,})"'),
+                lambda m: m.group(1) + '"' + tok('CUSTID', m.group(2)) + '"',
+            ),
+            (
+                re.compile(r'(PJSIP/)([A-Za-z0-9]{6,10})(@|/|-)'),
+                lambda m: m.group(1) + tok('ENDPOINT', m.group(2)) + m.group(3),
+            ),
+            (
+                re.compile(r'(stasis/p:mwi:all/)(\d+@\S+)'),
+                lambda m: m.group(1) + tok('MWISUB', m.group(2)),
+            ),
+            (
+                re.compile(r'(ctx-ID)(\d+)'),
+                lambda m: m.group(1) + tok('TENANT', m.group(2)),
+            ),
+            (
+                re.compile(r'(wazo-app-)([0-9a-f-]+)'),
+                lambda m: m.group(1) + tok('UUID', m.group(2)),
+            ),
+            (
+                re.compile(r'(pjsip/(?:options|outsess)/)([A-Za-z0-9]{6,10})(-)'),
+                lambda m: m.group(1) + tok('ENDPOINT', m.group(2)) + m.group(3),
+            ),
+            (
+                re.compile(r'(Local/)([A-Za-z0-9]{6,10})(@)'),
+                lambda m: m.group(1) + tok('ENDPOINT', m.group(2)) + m.group(3),
+            ),
+            (
+                re.compile(r'(PJSIP/)([A-Za-z0-9]{6,10})(-[0-9a-f]+)'),
+                lambda m: m.group(1) + tok('ENDPOINT', m.group(2)) + m.group(3),
+            ),
+            (
+                re.compile(r'grp-ID\d+-[0-9a-f-]+'),
+                lambda m: tok('GRP', m.group(0)),
+            ),
+            (
+                re.compile(r'(dial_mobile,\w+,)([A-Za-z0-9]{6,10})\b'),
+                lambda m: m.group(1) + tok('ENDPOINT', m.group(2)),
+            ),
+            (
+                re.compile(r'sip:[A-Za-z0-9]+@[\d.]+:\d+[^)\s]*'),
+                lambda m: tok('CONTACT', m.group(0)),
+            ),
+            (
+                re.compile(r'wazo-dial-mobile-[0-9a-f-]+'),
+                lambda m: tok('WAZODIAL', m.group(0)),
+            ),
+        ]
+
+        if phone_country:
+            national = NATIONAL_PHONE_PATTERNS.get(phone_country)
+            if national is None:
+                raise ValueError(
+                    f'unknown phone_country {phone_country!r}; known: '
+                    f'{sorted(NATIONAL_PHONE_PATTERNS)}'
+                )
+            rules.append((national, lambda m: tok('PHONE', m.group(0))))
+
+        rules += [
+            (re.compile(r'\+\d{10,15}'), lambda m: tok('PHONE', m.group(0))),
+            (
+                re.compile(
+                    r'\b(?!10\.)(?!172\.(?:1[6-9]|2\d|3[01])\.)(?!192\.168\.)'
+                    r'(?!127\.)(?!192\.0\.2\.)'
+                    r'(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b'
+                ),
+                lambda m: tok('IP', m.group(1)),
+            ),
+            (
+                re.compile(
+                    r'\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-'
+                    r'[0-9a-f]{4}-[0-9a-f]{12}\b'
+                ),
+                lambda m: tok('UUID', m.group(0)),
+            ),
+        ]
+
+        # --- caller-supplied raw regex escape hatch (applied last) ---
+        rules += [(re.compile(pat), repl) for pat, repl in extra_patterns]
+
+        return rules
+
+    def line(self, text: str) -> str:
+        for pattern, repl in self._rules:
+            text = pattern.sub(repl, text)
+        return text
+
+
+def anonymize_line(text: str) -> str:
+    """Structural-only sanitization of a single line (no caller config)."""
+    return Sanitizer().line(text)
 
 
 def extract_thread(lines: list[str], lwp: int) -> list[str]:
-    """Extract a single thread's backtrace from brief.txt lines."""
+    """Extract a single thread's backtrace from brief.txt lines by LWP."""
     result = []
     in_thread = False
     for line in lines:
@@ -109,32 +232,24 @@ def extract_thread(lines: list[str], lwp: int) -> list[str]:
     return result
 
 
-def extract_system_summary(info_path: Path) -> str:
-    """Extract anonymized system state summary from info.txt."""
-    text = info_path.read_text()
-    lines = text.splitlines()
+def extract_system_summary(info_path: Path, sanitizer: Sanitizer) -> str:
+    """Extract a sanitized system-state summary from an info.txt."""
+    lines = info_path.read_text().splitlines()
+    summary: list[str] = []
 
-    summary_lines = []
+    for line in lines[2:7]:  # header: version, build, uptime
+        summary.append(sanitizer.line(line))
 
-    # Header (version, build, uptime)
-    for line in lines[2:7]:
-        summary_lines.append(anonymize_line(line))
-
-    # TaskProcessors total
     for line in lines:
         if line.startswith('TaskProcessors ('):
-            summary_lines.append('')
-            summary_lines.append(line)
+            summary += ['', line]
             break
 
-    # Table header
     for line in lines:
         if line.startswith('Processor'):
-            summary_lines.append('')
-            summary_lines.append(line)
+            summary += ['', line]
             break
 
-    # Non-sensitive taskprocessors: list individually
     safe_prefixes = (
         'app_voicemail',
         'ast_msg_queue',
@@ -148,16 +263,13 @@ def extract_system_summary(info_path: Path) -> str:
         'pjsip/mwi',
     )
     for line in lines:
-        for pfx in safe_prefixes:
-            if line.startswith(pfx):
-                summary_lines.append(line)
-                break
+        if line.startswith(safe_prefixes):
+            summary.append(line)
 
-    # Summarize categories with counts
     tp_lines = [
         ln for ln in lines if not ln.startswith('Processor') and not ln.startswith('!')
     ]
-    categories = {
+    categories: dict[str, list[str]] = {
         'pjsip/options': [],
         'pjsip/outsess': [],
         'stasis/m:ari:application': [],
@@ -177,148 +289,168 @@ def extract_system_summary(info_path: Path) -> str:
         elif stripped.startswith('stasis/'):
             categories['stasis (other)'].append(stripped)
 
-    summary_lines.append('')
-    summary_lines.append('Taskprocessor categories (names anonymized):')
+    summary += ['', 'Taskprocessor categories (names anonymized):']
     for cat, cat_lines in categories.items():
         if not cat_lines:
             continue
-        # Parse numeric columns for aggregate stats
         queued_total = 0
-        max_depth_max = 0
+        max_depth = 0
         for cl in cat_lines:
             parts = cl.split()
             if len(parts) >= 4:
                 try:
                     queued_total += int(parts[-4])
-                    max_depth_max = max(max_depth_max, int(parts[-3]))
+                    max_depth = max(max_depth, int(parts[-3]))
                 except (ValueError, IndexError):
                     pass
-        summary_lines.append(
+        summary.append(
             f'  {cat}: {len(cat_lines)} taskprocessors, '
-            f'{queued_total} total in queue, '
-            f'max depth {max_depth_max}'
+            f'{queued_total} total in queue, max depth {max_depth}'
         )
 
-    # Channels and bridges count
-    summary_lines.append('')
+    summary.append('')
     for line in lines:
         if line.startswith('Channels (') or line.startswith('Bridges ('):
-            summary_lines.append(line)
+            summary.append(line)
 
-    return '\n'.join(summary_lines)
-
-
-def extract_log_around_crash(
-    log_path: Path, before: int = 5, after: int = 5
-) -> list[str]:
-    """Extract log lines around the crash timestamp."""
-    lines = log_path.read_text().splitlines()
-    # Find the freeze_check error line
-    crash_idx = None
-    for i, line in enumerate(lines):
-        if 'res_freeze_check' in line and 'failed to acquire' in line:
-            crash_idx = i
-            break
-    if crash_idx is None:
-        return ['(res_freeze_check message not found in log)']
-
-    start = max(0, crash_idx - before)
-    end = min(len(lines), crash_idx + after + 1)
-    return [anonymize_line(ln) for ln in lines[start:end]]
+    return '\n'.join(summary)
 
 
-def extract_endpoint_config_evidence(brief_lines: list[str], lwp: int) -> list[str]:
-    """Extract the key frames showing set_var -> PJSIP_HEADER code path."""
-    thread = extract_thread(brief_lines, lwp)
-    # Pick frames #7-#10 which show the set_var -> PJSIP_HEADER -> chan_pjsip_new path
-    evidence = []
-    for line in thread:
-        for frame in ('#7 ', '#8 ', '#9 ', '#10 '):
-            if line.startswith(frame):
-                evidence.append(anonymize_line(line))
-    return evidence
+def load_config(path: Path) -> dict:
+    config = json.loads(path.read_text())
+    if not isinstance(config, dict):
+        raise ValueError('config must be a JSON object')
+    return config
 
 
-def main():
-    base = Path(sys.argv[1]) if len(sys.argv) > 1 else Path('.')
-    prefix = 'core-asterisk-<timestamp>'
-
-    brief_path = base / f'{prefix}-brief.txt'
-    info_path = base / f'{prefix}-info.txt'
-    log_path = base / 'instance-1-logs' / 'instance-1-asterisk-logs' / 'full'
-
-    brief_lines = brief_path.read_text().splitlines()
-
-    # Thread LWPs from the crash analysis
-    # Thread 1158 (LWP 834925) - Dial thread holding channel lock
-    # Thread 780 (LWP 816915) - ARI thread holding container lock
-    dial_thread = extract_thread(brief_lines, 834925)
-    ari_thread = extract_thread(brief_lines, 816915)
-
-    output = []
-    output.append('# Sanitized coredump excerpts for upstream bug report')
-    output.append('')
-
-    # Endpoint set_var evidence
-    output.append('## Evidence of endpoint set_var configuration')
-    output.append('')
-    output.append(
-        'The stack trace shows `PJSIP_HEADER(add,X-CUSTOMER-ID)` being called from'
+def build_sanitizer(config: dict | None) -> Sanitizer:
+    config = config or {}
+    extra = tuple(
+        (entry['pattern'], entry['replacement']) for entry in config.get('patterns', [])
     )
-    output.append(
-        '`chan_pjsip_new()` via the endpoint `channel_vars` loop (set_var config):'
+    return Sanitizer(
+        literals=tuple(config.get('literals', [])),
+        domains=tuple(config.get('domains', [])),
+        headers=tuple(config.get('headers', [])),
+        extra_patterns=extra,
+        phone_country=config.get('phone_country'),
     )
-    output.append('```')
-    for line in extract_endpoint_config_evidence(brief_lines, 834925):
-        output.append(line)
-    output.append('```')
-    output.append('')
 
-    # Deadlock threads
-    output.append(
-        '## Thread A: Dial / chan_pjsip_new — holds channel lock, waiting on serializer'
+
+def _emit(text: str, output: str | None) -> None:
+    if output:
+        Path(output).write_text(text + '\n' if text else '')
+    else:
+        sys.stdout.write(text + '\n' if text else '')
+
+
+def _cmd_filter(args: argparse.Namespace, sanitizer: Sanitizer) -> None:
+    files = args.files or ['-']
+    out_lines = []
+    for name in files:
+        handle = sys.stdin if name == '-' else open(name, encoding='utf-8')
+        try:
+            for line in handle:
+                out_lines.append(sanitizer.line(line.rstrip('\n')))
+        finally:
+            if handle is not sys.stdin:
+                handle.close()
+    _emit('\n'.join(out_lines), args.output)
+
+
+def _cmd_thread(args: argparse.Namespace, sanitizer: Sanitizer) -> None:
+    lines = Path(args.brief).read_text().splitlines()
+    out: list[str] = []
+    for lwp in args.lwp:
+        out += [sanitizer.line(line) for line in extract_thread(lines, lwp)]
+    _emit('\n'.join(out), args.output)
+
+
+def _cmd_log(args: argparse.Namespace, sanitizer: Sanitizer) -> None:
+    lines = Path(args.logfile).read_text().splitlines()
+    marker = re.compile(args.marker)
+    idx = next((i for i, line in enumerate(lines) if marker.search(line)), None)
+    if idx is None:
+        sys.exit(f'marker {args.marker!r} not found in {args.logfile}')
+    start = max(0, idx - args.before)
+    end = min(len(lines), idx + args.after + 1)
+    _emit('\n'.join(sanitizer.line(line) for line in lines[start:end]), args.output)
+
+
+def _cmd_summary(args: argparse.Namespace, sanitizer: Sanitizer) -> None:
+    _emit(extract_system_summary(Path(args.info), sanitizer), args.output)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=(__doc__ or '').splitlines()[0])
+    parser.add_argument('--config', type=Path, help='JSON config of caller literals')
+    parser.add_argument(
+        '--mapping-out',
+        type=Path,
+        help='write the token->value de-anonymization key here (keep private)',
     )
-    output.append('```')
-    for line in dial_thread:
-        output.append(anonymize_line(line))
-    output.append('```')
-    output.append('')
-    output.append(
-        '## Thread B: ARI GET channel variable — holds container lock, '
-        'waiting on channel lock'
+    parser.add_argument(
+        '--structural-only',
+        action='store_true',
+        help='acknowledge running without caller literals (suppresses warning)',
     )
-    output.append('```')
-    for line in ari_thread:
-        output.append(anonymize_line(line))
-    output.append('```')
-    output.append('')
+    parser.add_argument('-o', '--output', help='write to file instead of stdout')
 
-    # Log excerpt
-    if log_path.exists():
-        output.append('## Asterisk log around crash time')
-        output.append('```')
-        for line in extract_log_around_crash(log_path):
-            output.append(line)
-        output.append('```')
-        output.append('')
+    sub = parser.add_subparsers(dest='cmd', required=True)
 
-    # System state
-    output.append('## System state at crash')
-    output.append('```')
-    output.append(extract_system_summary(info_path))
-    output.append('```')
+    p_filter = sub.add_parser('filter', help='sanitize lines from files or stdin')
+    p_filter.add_argument('files', nargs='*', help='input files (default: stdin)')
+    p_filter.set_defaults(func=_cmd_filter)
 
-    result = '\n'.join(output)
-    out_path = base / 'sanitized-coredump-excerpts.md'
-    out_path.write_text(result + '\n')
-    print(f'Written to {out_path}')
+    p_thread = sub.add_parser('thread', help='extract & sanitize thread(s) by LWP')
+    p_thread.add_argument('brief', help='ast_coredumper brief.txt')
+    p_thread.add_argument(
+        '--lwp',
+        type=int,
+        action='append',
+        required=True,
+        help='thread LWP (repeatable)',
+    )
+    p_thread.set_defaults(func=_cmd_thread)
 
-    # Anonymized info.txt (full structure preserved)
-    info_lines = info_path.read_text().splitlines()
-    anon_info = '\n'.join(anonymize_line(ln) for ln in info_lines)
-    anon_info_path = base / 'sanitized-info.txt'
-    anon_info_path.write_text(anon_info + '\n')
-    print(f'Written to {anon_info_path}')
+    p_log = sub.add_parser('log', help='extract & sanitize log lines around a marker')
+    p_log.add_argument('logfile')
+    p_log.add_argument(
+        '--marker', required=True, help='regex marking the line of interest'
+    )
+    p_log.add_argument('--before', type=int, default=5)
+    p_log.add_argument('--after', type=int, default=5)
+    p_log.set_defaults(func=_cmd_log)
+
+    p_summary = sub.add_parser('summary', help='sanitized system-state summary')
+    p_summary.add_argument('info', help='ast_coredumper info.txt')
+    p_summary.set_defaults(func=_cmd_summary)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _build_parser().parse_args(argv)
+    config = load_config(args.config) if args.config else None
+
+    has_literals = bool(
+        config
+        and (config.get('literals') or config.get('domains') or config.get('headers'))
+    )
+    if not has_literals and not args.structural_only:
+        print(
+            'WARNING: no caller literals configured (--config). Brand names, '
+            'vanity hostnames, tenant slugs and custom header values will NOT '
+            'be redacted — only generic structural patterns. Pass --config or '
+            '--structural-only to acknowledge.',
+            file=sys.stderr,
+        )
+
+    sanitizer = build_sanitizer(config)
+    args.func(args, sanitizer)
+
+    if args.mapping_out:
+        args.mapping_out.write_text(json.dumps(sanitizer.pseudo.mapping(), indent=2))
 
 
 if __name__ == '__main__':

--- a/sanitize-coredump/sanitize-coredump.py
+++ b/sanitize-coredump/sanitize-coredump.py
@@ -24,6 +24,7 @@ generalization; it remains in git history (commits d2dad71 / f8e7885).
 """
 
 import argparse
+import io
 import json
 import re
 import sys
@@ -40,7 +41,25 @@ Rule = tuple[re.Pattern, Replacement]
 # context rules.
 NATIONAL_PHONE_PATTERNS = {
     'FR': re.compile(r'\b0[1-9]\d{8}\b'),
+    'UK': re.compile(r'\b0\d{9,10}\b'),
 }
+
+
+def _truncatable_domain_regex(domain: str) -> str:
+    """Regex matching ``domain`` or any gdb-truncated prefix of it.
+
+    gdb cuts long strings at arbitrary points (``instance1.v"...``), so an
+    exact match misses the fragments. Keep a fixed head (the first dot-label,
+    at least 7 chars so a short generic prefix is not over-matched) and make
+    every following character independently optional.
+    """
+    labels = domain.split('.')
+    head_len = min(len(domain), max(len(labels[0]), 7))
+    head = re.escape(domain[:head_len])
+    tail = ''
+    for char in reversed(domain[head_len:]):
+        tail = f'(?:{re.escape(char)}{tail})?'
+    return head + tail
 
 
 class Pseudonymizer:
@@ -95,14 +114,13 @@ class Sanitizer:
         tok = self.pseudo.token
         rules: list[Rule] = []
 
-        # --- caller-supplied literals (longest first to avoid partial shadowing)
+        # --- caller-supplied domains and headers (specific contexts, run early)
         for domain in sorted(set(domains), key=len, reverse=True):
             rules.append(
-                (re.compile(re.escape(domain)), lambda m: tok('HOST', m.group(0)))
-            )
-        for literal in sorted(set(literals), key=len, reverse=True):
-            rules.append(
-                (re.compile(re.escape(literal)), lambda m: tok('LITERAL', m.group(0)))
+                (
+                    re.compile(_truncatable_domain_regex(domain)),
+                    lambda m: tok('HOST', m.group(0)),
+                )
             )
         for header in headers:
             rx = re.compile(
@@ -116,6 +134,13 @@ class Sanitizer:
 
         # --- built-in structural ruleset (order is load-bearing) ---
         rules += [
+            # Wazo trunk endpoint names <slug>_trunk_<hexid>; the slug AND the
+            # per-trunk id are customer-correlating, so token the whole name.
+            # Runs before the brand-literal rule so the slug is captured here.
+            (
+                re.compile(r'[A-Za-z0-9]+_trunk_[0-9a-f](?:[0-9a-f-]*[0-9a-f])?'),
+                lambda m: tok('TRUNK', m.group(0)),
+            ),
             (
                 re.compile(r'"([A-Z][a-z]+ [A-Z][a-z]+)"'),
                 lambda m: '"' + tok('NAME', m.group(1)) + '"',
@@ -194,13 +219,26 @@ class Sanitizer:
                 lambda m: tok('IP', m.group(1)),
             ),
             (
+                # UUID-shaped identifiers. The tail length is intentionally
+                # loose ([0-9a-f]+, not {12}) because real data carries
+                # truncated trunk UUIDs (8-4-4-4-9). No leading \b either: UUIDs
+                # appear glued to a prefix in SIP Via branches
+                # (z9hG4bKPj<uuid>). Over-redact rather than miss a
+                # customer-correlating id.
                 re.compile(
-                    r'\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-'
-                    r'[0-9a-f]{4}-[0-9a-f]{12}\b'
+                    r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]+'
                 ),
                 lambda m: tok('UUID', m.group(0)),
             ),
         ]
+
+        # --- caller-supplied brand literals (generic substrings, run late so
+        # they only catch standalone mentions, not parts of compound names
+        # already tokenized above; longest first to avoid partial shadowing)
+        for literal in sorted(set(literals), key=len, reverse=True):
+            rules.append(
+                (re.compile(re.escape(literal)), lambda m: tok('LITERAL', m.group(0)))
+            )
 
         # --- caller-supplied raw regex escape hatch (applied last) ---
         rules += [(re.compile(pat), repl) for pat, repl in extra_patterns]
@@ -234,7 +272,7 @@ def extract_thread(lines: list[str], lwp: int) -> list[str]:
 
 def extract_system_summary(info_path: Path, sanitizer: Sanitizer) -> str:
     """Extract a sanitized system-state summary from an info.txt."""
-    lines = info_path.read_text().splitlines()
+    lines = _read_text(info_path).splitlines()
     summary: list[str] = []
 
     for line in lines[2:7]:  # header: version, build, uptime
@@ -316,6 +354,18 @@ def extract_system_summary(info_path: Path, sanitizer: Sanitizer) -> str:
     return '\n'.join(summary)
 
 
+def _read_text(path: str | Path) -> str:
+    # Coredump logs routinely contain non-UTF-8 bytes; replace them rather than
+    # crash (and never round-trip raw bytes into the sanitized output).
+    return Path(path).read_text(encoding='utf-8', errors='replace')
+
+
+def _open_text(name: str) -> io.TextIOBase:
+    if name == '-':
+        return io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8', errors='replace')
+    return open(name, encoding='utf-8', errors='replace')
+
+
 def load_config(path: Path) -> dict:
     config = json.loads(path.read_text())
     if not isinstance(config, dict):
@@ -348,18 +398,18 @@ def _cmd_filter(args: argparse.Namespace, sanitizer: Sanitizer) -> None:
     files = args.files or ['-']
     out_lines = []
     for name in files:
-        handle = sys.stdin if name == '-' else open(name, encoding='utf-8')
+        handle = _open_text(name)
         try:
             for line in handle:
                 out_lines.append(sanitizer.line(line.rstrip('\n')))
         finally:
-            if handle is not sys.stdin:
+            if name != '-':
                 handle.close()
     _emit('\n'.join(out_lines), args.output)
 
 
 def _cmd_thread(args: argparse.Namespace, sanitizer: Sanitizer) -> None:
-    lines = Path(args.brief).read_text().splitlines()
+    lines = _read_text(args.brief).splitlines()
     out: list[str] = []
     for lwp in args.lwp:
         out += [sanitizer.line(line) for line in extract_thread(lines, lwp)]
@@ -367,7 +417,7 @@ def _cmd_thread(args: argparse.Namespace, sanitizer: Sanitizer) -> None:
 
 
 def _cmd_log(args: argparse.Namespace, sanitizer: Sanitizer) -> None:
-    lines = Path(args.logfile).read_text().splitlines()
+    lines = _read_text(args.logfile).splitlines()
     marker = re.compile(args.marker)
     idx = next((i for i, line in enumerate(lines) if marker.search(line)), None)
     if idx is None:

--- a/sanitize-coredump/sanitize-coredump.py
+++ b/sanitize-coredump/sanitize-coredump.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Extract and anonymize relevant coredump snippets for upstream bug report.
+
+Reads ast_coredumper output files (brief.txt, info.txt) and Asterisk logs,
+then produces sanitized excerpts suitable for public sharing.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# Patterns to redact
+PHONE_E164 = re.compile(r'\+\d{10,15}')
+PHONE_NATIONAL = re.compile(r'\b0[1-9]\d{9,10}\b')
+# Customer-identifying trunk/endpoint names: customer_trunk_<uuid>
+CUSTOMER_TRUNK = re.compile(r'customer_trunk_[0-9a-f-]+')
+# Short endpoint tokens (8-char alphanum used as PJSIP endpoint names)
+# Only match when in PJSIP context to avoid false positives
+PJSIP_ENDPOINT = re.compile(r'(PJSIP/)([A-Za-z0-9]{6,10})(@|/|-)')
+# Customer ID values (numeric, in X-CUSTOMER-ID context)
+CUSTOMER_ID_VAL = re.compile(
+    r'("PJSIP_HEADER\(add,X-CUSTOMER-ID\)", value=0x[0-9a-f]+ )"[0-9]+"'
+)
+HEADER_VAL = re.compile(r'(data=0x[0-9a-f]+ "add", value=0x[0-9a-f]+ )"[0-9]+"')
+# Bare numeric string values (customer IDs etc.) in value= arguments
+VALUE_NUMERIC = re.compile(r'(value=[^ ]+ )"(\d{6,})"')
+# Hostname
+CUSTOMER_HOST = re.compile(r'instance\d+\.voip\d+\.customer\.com')
+# Public IPs (not RFC1918, not loopback, not documentation range)
+PUBLIC_IP = re.compile(
+    r'\b(?!10\.)(?!172\.(?:1[6-9]|2\d|3[01])\.)(?!192\.168\.)(?!127\.)(?!192\.0\.2\.)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\b'
+)
+# Personal names in SIP From display names won't appear in brief.txt thread excerpts
+# but guard against them anyway
+SIP_DISPLAY_NAME = re.compile(r'"([A-Z][a-z]+ [A-Z][a-z]+)"')
+# callerid in ast_spawn_extension
+CALLERID_ARG = re.compile(r'(callerid=0x[0-9a-f]+ )"\+?\d{10,15}"')
+# Context names with tenant IDs
+CTX_ID = re.compile(r'ctx-ID\d+-')
+# Wazo app UUIDs
+WAZO_APP = re.compile(r'wazo-app-[0-9a-f-]+')
+# Endpoint tokens in taskprocessor/channel names (8-char alphanum)
+# e.g. pjsip/options/ABcD1234-00000040, pjsip/outsess/ABcD1234-00000040
+TP_ENDPOINT = re.compile(r'(pjsip/(?:options|outsess)/)([A-Za-z0-9]{6,10})(-)')
+# stasis/p:mwi:all/<ext>@<context>-<tp_hex>
+# Formats: <num>@ctx-ID<num>-internal-<hex>-<hex>-<tp>
+#          <num>@default-internal-<token>-<tp>
+#          <num>@ctx-<token>-internal-<hex>-<hex>-<tp>
+MWI_SUB = re.compile(r'(stasis/p:mwi:all/)\d+@\S+')
+# Local channel with endpoint token: Local/<token>@context
+LOCAL_CHAN_ENDPOINT = re.compile(r'(Local/)[A-Za-z0-9]{6,10}(@)')
+# PJSIP channel names: PJSIP/<endpoint>-<hex>
+PJSIP_CHAN = re.compile(r'(PJSIP/)([A-Za-z0-9]{6,10})(-[0-9a-f]+)')
+# Bridge UUIDs (standalone UUID pattern in bridge/channel table)
+BRIDGE_UUID = re.compile(
+    r'\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b'
+)
+# grp-ID<num>-<uuid> group identifiers
+GRP_ID = re.compile(r'grp-ID\d+-[0-9a-f-]+')
+# dial_mobile data: dial_mobile,<action>,<endpoint>
+DIAL_MOBILE = re.compile(r'(dial_mobile,\w+,)[A-Za-z0-9]{6,10}')
+# Dial string with SIP contact URI: sip:<user>@<ip>:<port>
+SIP_CONTACT = re.compile(r'sip:[A-Za-z0-9]+@[\d.]+:\d+[^)\s]*')
+# wazo-dial-mobile-<uuid>
+WAZO_DIAL_MOBILE = re.compile(r'wazo-dial-mobile-[0-9a-f-]+')
+
+
+def anonymize_line(line: str) -> str:
+    line = CUSTOMER_TRUNK.sub(
+        'example_trunk_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', line
+    )
+    line = CUSTOMER_HOST.sub('sip.example.com', line)
+    line = CUSTOMER_ID_VAL.sub(r'\1"XXXXXXXX"', line)
+    line = HEADER_VAL.sub(r'\1"XXXXXXXX"', line)
+    line = VALUE_NUMERIC.sub(r'\1"XXXXXXXX"', line)
+    line = CALLERID_ARG.sub(r'\1"+XXXXXXXXXXXX"', line)
+    line = PJSIP_ENDPOINT.sub(r'\1ENDPOINT\3', line)
+    line = MWI_SUB.sub(r'\1XXXXXXX@XXXXX-XXXXX', line)
+    line = CTX_ID.sub('ctx-IDXXXXXXXX-', line)
+    line = WAZO_APP.sub('wazo-app-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', line)
+    line = TP_ENDPOINT.sub(r'\1ENDPOINT\3', line)
+    line = LOCAL_CHAN_ENDPOINT.sub(r'\1ENDPOINT\2', line)
+    line = PJSIP_CHAN.sub(r'\1ENDPOINT\3', line)
+    line = GRP_ID.sub('grp-IDXXXXXXXX-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', line)
+    line = DIAL_MOBILE.sub(r'\1ENDPOINT', line)
+    line = SIP_CONTACT.sub('sip:XXXXX@X.X.X.X:XXXXX', line)
+    line = WAZO_DIAL_MOBILE.sub(
+        'wazo-dial-mobile-XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', line
+    )
+    line = PHONE_E164.sub('+XXXXXXXXXXXX', line)
+    line = PHONE_NATIONAL.sub('0XXXXXXXXXX', line)
+    line = PUBLIC_IP.sub('X.X.X.X', line)
+    line = BRIDGE_UUID.sub('XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX', line)
+    return line
+
+
+def extract_thread(lines: list[str], lwp: int) -> list[str]:
+    """Extract a single thread's backtrace from brief.txt lines."""
+    result = []
+    in_thread = False
+    for line in lines:
+        if f'LWP {lwp})' in line and line.startswith('Thread '):
+            in_thread = True
+        elif in_thread and line.startswith('Thread '):
+            break
+        if in_thread:
+            result.append(line)
+    return result
+
+
+def extract_system_summary(info_path: Path) -> str:
+    """Extract anonymized system state summary from info.txt."""
+    text = info_path.read_text()
+    lines = text.splitlines()
+
+    summary_lines = []
+
+    # Header (version, build, uptime)
+    for line in lines[2:7]:
+        summary_lines.append(anonymize_line(line))
+
+    # TaskProcessors total
+    for line in lines:
+        if line.startswith('TaskProcessors ('):
+            summary_lines.append('')
+            summary_lines.append(line)
+            break
+
+    # Table header
+    for line in lines:
+        if line.startswith('Processor'):
+            summary_lines.append('')
+            summary_lines.append(line)
+            break
+
+    # Non-sensitive taskprocessors: list individually
+    safe_prefixes = (
+        'app_voicemail',
+        'ast_msg_queue',
+        'CCSS_core',
+        'dns_system',
+        'hep_queue_tp',
+        'iax2_transmit',
+        'pjsip/distributor',
+        'pjsip/exten_state',
+        'pjsip/messaging',
+        'pjsip/mwi',
+    )
+    for line in lines:
+        for pfx in safe_prefixes:
+            if line.startswith(pfx):
+                summary_lines.append(line)
+                break
+
+    # Summarize categories with counts
+    tp_lines = [
+        ln for ln in lines if not ln.startswith('Processor') and not ln.startswith('!')
+    ]
+    categories = {
+        'pjsip/options': [],
+        'pjsip/outsess': [],
+        'stasis/m:ari:application': [],
+        'stasis/p:mwi:all': [],
+        'stasis (other)': [],
+    }
+    for line in tp_lines:
+        stripped = line.strip()
+        if stripped.startswith('pjsip/options/'):
+            categories['pjsip/options'].append(stripped)
+        elif stripped.startswith('pjsip/outsess/'):
+            categories['pjsip/outsess'].append(stripped)
+        elif stripped.startswith('stasis/m:ari:application/'):
+            categories['stasis/m:ari:application'].append(stripped)
+        elif stripped.startswith('stasis/p:mwi:all/'):
+            categories['stasis/p:mwi:all'].append(stripped)
+        elif stripped.startswith('stasis/'):
+            categories['stasis (other)'].append(stripped)
+
+    summary_lines.append('')
+    summary_lines.append('Taskprocessor categories (names anonymized):')
+    for cat, cat_lines in categories.items():
+        if not cat_lines:
+            continue
+        # Parse numeric columns for aggregate stats
+        queued_total = 0
+        max_depth_max = 0
+        for cl in cat_lines:
+            parts = cl.split()
+            if len(parts) >= 4:
+                try:
+                    queued_total += int(parts[-4])
+                    max_depth_max = max(max_depth_max, int(parts[-3]))
+                except (ValueError, IndexError):
+                    pass
+        summary_lines.append(
+            f'  {cat}: {len(cat_lines)} taskprocessors, '
+            f'{queued_total} total in queue, '
+            f'max depth {max_depth_max}'
+        )
+
+    # Channels and bridges count
+    summary_lines.append('')
+    for line in lines:
+        if line.startswith('Channels (') or line.startswith('Bridges ('):
+            summary_lines.append(line)
+
+    return '\n'.join(summary_lines)
+
+
+def extract_log_around_crash(
+    log_path: Path, before: int = 5, after: int = 5
+) -> list[str]:
+    """Extract log lines around the crash timestamp."""
+    lines = log_path.read_text().splitlines()
+    # Find the freeze_check error line
+    crash_idx = None
+    for i, line in enumerate(lines):
+        if 'res_freeze_check' in line and 'failed to acquire' in line:
+            crash_idx = i
+            break
+    if crash_idx is None:
+        return ['(res_freeze_check message not found in log)']
+
+    start = max(0, crash_idx - before)
+    end = min(len(lines), crash_idx + after + 1)
+    return [anonymize_line(ln) for ln in lines[start:end]]
+
+
+def extract_endpoint_config_evidence(brief_lines: list[str], lwp: int) -> list[str]:
+    """Extract the key frames showing set_var -> PJSIP_HEADER code path."""
+    thread = extract_thread(brief_lines, lwp)
+    # Pick frames #7-#10 which show the set_var -> PJSIP_HEADER -> chan_pjsip_new path
+    evidence = []
+    for line in thread:
+        for frame in ('#7 ', '#8 ', '#9 ', '#10 '):
+            if line.startswith(frame):
+                evidence.append(anonymize_line(line))
+    return evidence
+
+
+def main():
+    base = Path(sys.argv[1]) if len(sys.argv) > 1 else Path('.')
+    prefix = 'core-asterisk-<timestamp>'
+
+    brief_path = base / f'{prefix}-brief.txt'
+    info_path = base / f'{prefix}-info.txt'
+    log_path = base / 'instance-1-logs' / 'instance-1-asterisk-logs' / 'full'
+
+    brief_lines = brief_path.read_text().splitlines()
+
+    # Thread LWPs from the crash analysis
+    # Thread 1158 (LWP 834925) - Dial thread holding channel lock
+    # Thread 780 (LWP 816915) - ARI thread holding container lock
+    dial_thread = extract_thread(brief_lines, 834925)
+    ari_thread = extract_thread(brief_lines, 816915)
+
+    output = []
+    output.append('# Sanitized coredump excerpts for upstream bug report')
+    output.append('')
+
+    # Endpoint set_var evidence
+    output.append('## Evidence of endpoint set_var configuration')
+    output.append('')
+    output.append(
+        'The stack trace shows `PJSIP_HEADER(add,X-CUSTOMER-ID)` being called from'
+    )
+    output.append(
+        '`chan_pjsip_new()` via the endpoint `channel_vars` loop (set_var config):'
+    )
+    output.append('```')
+    for line in extract_endpoint_config_evidence(brief_lines, 834925):
+        output.append(line)
+    output.append('```')
+    output.append('')
+
+    # Deadlock threads
+    output.append(
+        '## Thread A: Dial / chan_pjsip_new — holds channel lock, waiting on serializer'
+    )
+    output.append('```')
+    for line in dial_thread:
+        output.append(anonymize_line(line))
+    output.append('```')
+    output.append('')
+    output.append(
+        '## Thread B: ARI GET channel variable — holds container lock, '
+        'waiting on channel lock'
+    )
+    output.append('```')
+    for line in ari_thread:
+        output.append(anonymize_line(line))
+    output.append('```')
+    output.append('')
+
+    # Log excerpt
+    if log_path.exists():
+        output.append('## Asterisk log around crash time')
+        output.append('```')
+        for line in extract_log_around_crash(log_path):
+            output.append(line)
+        output.append('```')
+        output.append('')
+
+    # System state
+    output.append('## System state at crash')
+    output.append('```')
+    output.append(extract_system_summary(info_path))
+    output.append('```')
+
+    result = '\n'.join(output)
+    out_path = base / 'sanitized-coredump-excerpts.md'
+    out_path.write_text(result + '\n')
+    print(f'Written to {out_path}')
+
+    # Anonymized info.txt (full structure preserved)
+    info_lines = info_path.read_text().splitlines()
+    anon_info = '\n'.join(anonymize_line(ln) for ln in info_lines)
+    anon_info_path = base / 'sanitized-info.txt'
+    anon_info_path.write_text(anon_info + '\n')
+    print(f'Written to {anon_info_path}')
+
+
+if __name__ == '__main__':
+    main()

--- a/sanitize-coredump/sanitize-coredump.py
+++ b/sanitize-coredump/sanitize-coredump.py
@@ -74,6 +74,7 @@ def anonymize_line(line: str) -> str:
     line = HEADER_VAL.sub(r'\1"XXXXXXXX"', line)
     line = VALUE_NUMERIC.sub(r'\1"XXXXXXXX"', line)
     line = CALLERID_ARG.sub(r'\1"+XXXXXXXXXXXX"', line)
+    line = SIP_DISPLAY_NAME.sub('"REDACTED NAME"', line)
     line = PJSIP_ENDPOINT.sub(r'\1ENDPOINT\3', line)
     line = MWI_SUB.sub(r'\1XXXXXXX@XXXXX-XXXXX', line)
     line = CTX_ID.sub('ctx-IDXXXXXXXX-', line)

--- a/sanitize-coredump/sanitize-coredump.py
+++ b/sanitize-coredump/sanitize-coredump.py
@@ -44,6 +44,32 @@ NATIONAL_PHONE_PATTERNS = {
     'UK': re.compile(r'\b0\d{9,10}\b'),
 }
 
+# Pseudonym tokens are TAG_<n>. To let endpoint-name rules match underscore-
+# bearing names (e.g. ACS_INTERIM_UNYC) without re-matching a generated token,
+# guard against anything shaped like a token.
+_TOKEN_TAGS = (
+    'ENDPOINT',
+    'TRUNK',
+    'IP',
+    'UUID',
+    'PHONE',
+    'CONTACT',
+    'NAME',
+    'TENANT',
+    'GRP',
+    'MWISUB',
+    'CUSTID',
+    'HOST',
+    'HEADERVAL',
+    'WAZODIAL',
+    'WAZOAPP',
+    'LITERAL',
+)
+_NOT_A_TOKEN = r'(?!(?:' + '|'.join(_TOKEN_TAGS) + r')_\d)'
+# An endpoint name carrying at least one underscore (business/customer names
+# like ALLIANZ_ANNE_BAILLET_UNYC), never a generated token.
+_UNDERSCORE_NAME = _NOT_A_TOKEN + r'[A-Za-z0-9]+(?:_[A-Za-z0-9]+)+'
+
 # IPv6 matcher. Only "strong" forms are matched (full 8 groups, a hex group
 # before '::', or IPv4-mapped/embedded) so bare 'ns::Sym' tokens common in gdb
 # backtraces are not mangled; the digit requirement (enforced in the
@@ -167,6 +193,29 @@ class Sanitizer:
                 re.compile(r'[A-Za-z0-9]+_trunk_[A-Za-z0-9][A-Za-z0-9_-]*'),
                 lambda m: tok('TRUNK', m.group(0)),
             ),
+            # Endpoint names carrying underscores (business/customer names such
+            # as ALLIANZ_ANNE_BAILLET_UNYC) in registration/option/channel
+            # contexts. The [A-Za-z0-9]{6,10} rules below only cover token-shaped
+            # names; these cover the underscored ones. Shared ENDPOINT tag keeps
+            # the same endpoint correlated across contexts.
+            (
+                re.compile(rf'(pjsip/(?:options|outsess|outreg)/)({_UNDERSCORE_NAME})'),
+                lambda m: m.group(1) + tok('ENDPOINT', m.group(2)),
+            ),
+            (
+                re.compile(rf'(PJSIP/)({_UNDERSCORE_NAME})'),
+                lambda m: m.group(1) + tok('ENDPOINT', m.group(2)),
+            ),
+            (
+                re.compile(rf'(Local/)({_UNDERSCORE_NAME})'),
+                lambda m: m.group(1) + tok('ENDPOINT', m.group(2)),
+            ),
+            # NOTE: endpoint names also appear after '@' (PJSIP/<res>@<endpoint>),
+            # but that position is shared with standard Wazo contexts/vars
+            # (@wazo_wait, @WAZO_USER) which must NOT be redacted, so it cannot be
+            # handled structurally. A deployment whose endpoint names carry a
+            # stable marker (e.g. the *_UNYC suffix) should redact them via a
+            # --config pattern.
             (
                 re.compile(r'"([A-Z][a-z]+ [A-Z][a-z]+)"'),
                 lambda m: '"' + tok('NAME', m.group(1)) + '"',
@@ -191,7 +240,10 @@ class Sanitizer:
                 lambda m: m.group(1) + tok('MWISUB', m.group(2)),
             ),
             (
-                re.compile(r'(ctx-ID)(\d+)'),
+                # context names ctx-<tenant>-internal-...; the tenant is
+                # numeric (ctx-ID42) or a (often truncated) business name
+                # (ctx-CABINETOPH). Guard against re-matching a TENANT_n token.
+                re.compile(rf'(ctx-)({_NOT_A_TOKEN}[A-Za-z0-9]+)'),
                 lambda m: m.group(1) + tok('TENANT', m.group(2)),
             ),
             (
@@ -199,7 +251,9 @@ class Sanitizer:
                 lambda m: m.group(1) + tok('UUID', m.group(2)),
             ),
             (
-                re.compile(r'(pjsip/(?:options|outsess)/)([A-Za-z0-9]{6,10})(-)'),
+                re.compile(
+                    r'(pjsip/(?:options|outsess|outreg)/)([A-Za-z0-9]{6,10})(-)'
+                ),
                 lambda m: m.group(1) + tok('ENDPOINT', m.group(2)) + m.group(3),
             ),
             (

--- a/sanitize-coredump/sanitize-coredump.py
+++ b/sanitize-coredump/sanitize-coredump.py
@@ -138,7 +138,9 @@ class Sanitizer:
             # per-trunk id are customer-correlating, so token the whole name.
             # Runs before the brand-literal rule so the slug is captured here.
             (
-                re.compile(r'[A-Za-z0-9]+_trunk_[0-9a-f](?:[0-9a-f-]*[0-9a-f])?'),
+                # require >=8 hex for the id so non-id names like
+                # default_trunk_config are not mangled.
+                re.compile(r'[A-Za-z0-9]+_trunk_[0-9a-f]{8}[0-9a-f-]*'),
                 lambda m: tok('TRUNK', m.group(0)),
             ),
             (

--- a/sanitize-coredump/sanitize-coredump.py
+++ b/sanitize-coredump/sanitize-coredump.py
@@ -156,13 +156,15 @@ class Sanitizer:
 
         # --- built-in structural ruleset (order is load-bearing) ---
         rules += [
-            # Wazo trunk endpoint names <slug>_trunk_<hexid>; the slug AND the
-            # per-trunk id are customer-correlating, so token the whole name.
-            # Runs before the brand-literal rule so the slug is captured here.
+            # Wazo trunk endpoint names <slug>_trunk_<id>; the slug AND the id
+            # are customer-correlating, so token the whole name. The id is not
+            # always a hex UUID — real deployments use human/business names
+            # (e.g. dstny_trunk_ChapelleTrucksServices), so match any identifier
+            # after '_trunk_'. Validated across the support corpus that
+            # '_trunk_' only ever appears inside endpoint names, so this does
+            # not over-redact unrelated text. Runs before the brand-literal rule.
             (
-                # require >=8 hex for the id so non-id names like
-                # default_trunk_config are not mangled.
-                re.compile(r'[A-Za-z0-9]+_trunk_[0-9a-f]{8}[0-9a-f-]*'),
+                re.compile(r'[A-Za-z0-9]+_trunk_[A-Za-z0-9][A-Za-z0-9_-]*'),
                 lambda m: tok('TRUNK', m.group(0)),
             ),
             (
@@ -193,7 +195,7 @@ class Sanitizer:
                 lambda m: m.group(1) + tok('TENANT', m.group(2)),
             ),
             (
-                re.compile(r'(wazo-app-)([0-9a-f-]+)'),
+                re.compile(r'(wazo-app-)([0-9a-fA-F-]+)'),
                 lambda m: m.group(1) + tok('UUID', m.group(2)),
             ),
             (
@@ -209,7 +211,7 @@ class Sanitizer:
                 lambda m: m.group(1) + tok('ENDPOINT', m.group(2)) + m.group(3),
             ),
             (
-                re.compile(r'grp-ID\d+-[0-9a-f-]+'),
+                re.compile(r'grp-ID\d+-[0-9a-fA-F-]+'),
                 lambda m: tok('GRP', m.group(0)),
             ),
             (
@@ -217,11 +219,14 @@ class Sanitizer:
                 lambda m: m.group(1) + tok('ENDPOINT', m.group(2)),
             ),
             (
-                re.compile(r'sip:[A-Za-z0-9]+@[\d.]+:\d+[^)\s]*'),
+                # host is dotted IPv4 or a bracketed IPv6 literal; runs before
+                # the standalone IPv6 rule so the whole URI is one token (user
+                # included), not a half-redacted address.
+                re.compile(r'sip:[A-Za-z0-9]+@(?:[\d.]+|\[[0-9A-Fa-f:]+\]):\d+[^)\s]*'),
                 lambda m: tok('CONTACT', m.group(0)),
             ),
             (
-                re.compile(r'wazo-dial-mobile-[0-9a-f-]+'),
+                re.compile(r'wazo-dial-mobile-[0-9a-fA-F-]+'),
                 lambda m: tok('WAZODIAL', m.group(0)),
             ),
         ]
@@ -263,7 +268,8 @@ class Sanitizer:
                 # (z9hG4bKPj<uuid>). Over-redact rather than miss a
                 # customer-correlating id.
                 re.compile(
-                    r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]+'
+                    r'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-'
+                    r'[0-9a-fA-F]{4}-[0-9a-fA-F]+'
                 ),
                 lambda m: tok('UUID', m.group(0)),
             ),
@@ -339,7 +345,7 @@ def extract_system_summary(info_path: Path, sanitizer: Sanitizer) -> str:
     )
     for line in lines:
         if line.startswith(safe_prefixes):
-            summary.append(line)
+            summary.append(sanitizer.line(line))
 
     tp_lines = [
         ln for ln in lines if not ln.startswith('Processor') and not ln.startswith('!')
@@ -386,7 +392,7 @@ def extract_system_summary(info_path: Path, sanitizer: Sanitizer) -> str:
     summary.append('')
     for line in lines:
         if line.startswith('Channels (') or line.startswith('Bridges ('):
-            summary.append(line)
+            summary.append(sanitizer.line(line))
 
     return '\n'.join(summary)
 

--- a/sanitize-coredump/test_sanitize_coredump.py
+++ b/sanitize-coredump/test_sanitize_coredump.py
@@ -90,6 +90,17 @@ REDACTION_CASES = [
         'contact sip:user123@1.2.3.4:5060;ob', 'user123', id='sip contact uri'
     ),
     pytest.param('peer 8.8.8.8 reachable', '8.8.8.8', id='public ip'),
+    pytest.param(
+        'peer 2606:4700:4700::1111 up',
+        '2606:4700:4700::1111',
+        id='public ipv6 compressed',
+    ),
+    pytest.param(
+        'addr 2a00:1450:4007:80f::200e end',
+        '2a00:1450:4007:80f::200e',
+        id='public ipv6',
+    ),
+    pytest.param('sock ::ffff:8.8.8.8 bound', '8.8.8.8', id='ipv4-mapped ipv6'),
 ]
 
 
@@ -106,6 +117,18 @@ def test_private_ip_is_preserved():
 
 def test_loopback_ip_is_preserved():
     assert '127.0.0.1' in anonymize_line('bound to 127.0.0.1:5060')
+
+
+def test_ipv6_loopback_and_link_local_preserved():
+    assert '::1' in anonymize_line('bind [::1]:5060')
+    assert 'fe80::1' in anonymize_line('iface fe80::1 up')
+
+
+def test_ipv6_rule_does_not_corrupt_cpp_symbols_or_timestamps():
+    # gdb backtraces are full of ns::Sym tokens and HH:MM:SS timestamps
+    assert anonymize_line('frame ast::unload_resource') == 'frame ast::unload_resource'
+    assert anonymize_line('cafe::babe handler') == 'cafe::babe handler'
+    assert anonymize_line('reload at 11:20:54 done') == 'reload at 11:20:54 done'
 
 
 def test_trunk_name_fully_redacted():

--- a/sanitize-coredump/test_sanitize_coredump.py
+++ b/sanitize-coredump/test_sanitize_coredump.py
@@ -72,6 +72,16 @@ REDACTION_CASES = [
         id='bridge uuid',
     ),
     pytest.param(
+        'ref 0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4 seen',
+        '0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4',
+        id='truncated trunk uuid (9-hex tail)',
+    ),
+    pytest.param(
+        'branch=z9hG4bKPj0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4678;alias',
+        '0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4678',
+        id='uuid glued to SIP Via branch prefix',
+    ),
+    pytest.param(
         'contact sip:user123@1.2.3.4:5060;ob', 'user123', id='sip contact uri'
     ),
     pytest.param('peer 8.8.8.8 reachable', '8.8.8.8', id='public ip'),
@@ -91,6 +101,16 @@ def test_private_ip_is_preserved():
 
 def test_loopback_ip_is_preserved():
     assert '127.0.0.1' in anonymize_line('bound to 127.0.0.1:5060')
+
+
+def test_trunk_name_fully_redacted():
+    # real trunk ids carry a non-standard UUID the UUID rule misses, so the
+    # dedicated trunk rule must capture the whole <slug>_trunk_<id> name.
+    out = anonymize_line(
+        'PJSIP/customer_trunk_1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5-00000bc0 up'
+    )
+    assert 'customer_trunk' not in out
+    assert '1a2b3c4d' not in out
 
 
 # --- pseudonymization mechanics ---
@@ -142,6 +162,13 @@ def test_config_domain_is_redacted():
     assert 'customer.com' not in out
 
 
+def test_config_domain_redacted_even_when_gdb_truncated():
+    sanitizer = Sanitizer(domains=('instance1.voip3.customer.com',))
+    assert 'voip3' not in sanitizer.line('aor user@instance1.voip3.bo"..., payload')
+    # gdb may cut even shorter, mid-second-label
+    assert 'instance1' not in sanitizer.line('<sip:abc@instance1.v"..., payload')
+
+
 def test_config_header_value_is_redacted():
     out = Sanitizer(headers=('X-TENANT-NAME',)).line(
         '"PJSIP_HEADER(add,X-TENANT-NAME)", value=0x7f001234 "AcmeCorp"'
@@ -160,6 +187,15 @@ def test_national_phone_redacted_when_country_configured():
 def test_cli_filter_sanitizes(tmp_path, capsys):
     src = tmp_path / 'in.txt'
     src.write_text('peer 8.8.8.8 reachable\n')
+    main(['--structural-only', 'filter', str(src)])
+    out = capsys.readouterr().out
+    assert '8.8.8.8' not in out
+    assert 'IP_1' in out
+
+
+def test_cli_filter_handles_non_utf8_bytes(tmp_path, capsys):
+    src = tmp_path / 'bin.txt'
+    src.write_bytes(b'peer 8.8.8.8 \x97 raw byte\n')
     main(['--structural-only', 'filter', str(src)])
     out = capsys.readouterr().out
     assert '8.8.8.8' not in out

--- a/sanitize-coredump/test_sanitize_coredump.py
+++ b/sanitize-coredump/test_sanitize_coredump.py
@@ -19,6 +19,7 @@ _spec.loader.exec_module(_module)
 
 anonymize_line = _module.anonymize_line
 Sanitizer = _module.Sanitizer
+extract_system_summary = _module.extract_system_summary
 main = _module.main
 
 
@@ -101,6 +102,16 @@ REDACTION_CASES = [
         id='public ipv6',
     ),
     pytest.param('sock ::ffff:8.8.8.8 bound', '8.8.8.8', id='ipv4-mapped ipv6'),
+    pytest.param(
+        'id A1B2C3D4-E5F6-7A8B-9C0D-E1F2A3B4C5D6 seen',
+        'A1B2C3D4-E5F6-7A8B-9C0D-E1F2A3B4C5D6',
+        id='uppercase-hex uuid',
+    ),
+    pytest.param(
+        'PJSIP/customer_trunk_DEADBEEF-1111-2222-3333-44445555 up',
+        'DEADBEEF',
+        id='uppercase-hex trunk id',
+    ),
 ]
 
 
@@ -131,6 +142,40 @@ def test_ipv6_rule_does_not_corrupt_cpp_symbols_or_timestamps():
     assert anonymize_line('reload at 11:20:54 done') == 'reload at 11:20:54 done'
 
 
+def test_sip_contact_with_ipv6_collapses_to_single_token():
+    out = anonymize_line('c sip:user42@[2606:4700::1111]:5060;ob done')
+    assert 'user42' not in out  # user redacted, not just the address
+    assert '2606:4700' not in out
+    assert out.count('CONTACT_') == 1  # one token, not a half-redacted URI
+    assert 'IP_' not in out  # not split by the standalone IPv6 rule
+
+
+def test_summary_sanitizes_safe_prefix_lines(tmp_path):
+    # the safe_prefix taskprocessor lines must be sanitized, not emitted raw
+    info = tmp_path / 'info.txt'
+    info.write_text(
+        '\n'.join(
+            [
+                'header0',
+                'header1',
+                'Asterisk 22 built',
+                'started',
+                'reload',
+                '',
+                '',
+                'TaskProcessors (1):',
+                '',
+                'Processor   Processed',
+                'pjsip/messaging  a1b2c3d4-e5f6-7a8b-9c0d-112233445566  0  0',
+                'Channels (0)',
+                'Bridges (0)',
+            ]
+        )
+    )
+    out = extract_system_summary(info, Sanitizer())
+    assert 'a1b2c3d4-e5f6-7a8b-9c0d-112233445566' not in out
+
+
 def test_trunk_name_fully_redacted():
     # real trunk ids carry a non-standard UUID the UUID rule misses, so the
     # dedicated trunk rule must capture the whole <slug>_trunk_<id> name.
@@ -141,9 +186,13 @@ def test_trunk_name_fully_redacted():
     assert '1a2b3c4d' not in out
 
 
-def test_trunk_rule_does_not_mangle_non_id_names():
-    # a config-like name (no uuid id) must be left intact, not half-eaten
-    assert anonymize_line('default_trunk_config') == 'default_trunk_config'
+def test_human_named_trunk_is_redacted():
+    # real trunk ids are not always hex UUIDs; some carry person/business names
+    out = anonymize_line('PJSIP/dstny_trunk_Adil_Aube-0000021c answered')
+    assert 'Adil_Aube' not in out
+    assert 'dstny_trunk' not in out
+    out2 = anonymize_line('chan dstny_trunk_ChapelleTrucksServices-00000216 up')
+    assert 'ChapelleTrucksServices' not in out2
 
 
 # --- pseudonymization mechanics ---

--- a/sanitize-coredump/test_sanitize_coredump.py
+++ b/sanitize-coredump/test_sanitize_coredump.py
@@ -288,6 +288,16 @@ def test_config_header_value_is_redacted():
     assert 'AcmeCorp' not in out
 
 
+def test_empty_config_literal_is_ignored():
+    out = Sanitizer(literals=('', 'customer')).line('hello customer world')
+    assert out == 'hello LITERAL_1 world'
+
+
+def test_empty_config_domain_is_ignored():
+    out = Sanitizer(domains=('',)).line('hello world this is a test')
+    assert out == 'hello world this is a test'
+
+
 def test_national_phone_redacted_when_country_configured():
     out = Sanitizer(phone_country='FR').line('from 0612345678 here')
     assert '0612345678' not in out

--- a/sanitize-coredump/test_sanitize_coredump.py
+++ b/sanitize-coredump/test_sanitize_coredump.py
@@ -1,0 +1,94 @@
+"""Tests proving each redaction pattern in sanitize-coredump.py actually fires.
+
+For a sanitizer the cardinal failure is the false negative (a leak), so every
+pattern gets a case asserting the sensitive token does not survive in the
+output. The module filename has a dash, so it is loaded via importlib.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = Path(__file__).parent / 'sanitize-coredump.py'
+_spec = importlib.util.spec_from_file_location('sanitize_coredump', _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+anonymize_line = _module.anonymize_line
+
+
+# pytest.param(input line, substring that MUST NOT survive, id=pattern name)
+REDACTION_CASES = [
+    pytest.param('caller +33612345678 dialed', '+33612345678', id='phone E164'),
+    pytest.param(
+        'from 0612345678 here',
+        '0612345678',
+        id='phone national',
+        marks=pytest.mark.xfail(
+            reason='PHONE_NATIONAL is FR-specific; needs per-country handling '
+            '(see GENERALIZATION-PLAN.md)',
+            strict=True,
+        ),
+    ),
+    pytest.param(
+        'endpoint=customer_trunk_ab12cd34-ef', 'customer_trunk', id='customer trunk'
+    ),
+    pytest.param(
+        'host instance1.voip2.customer.com up', 'customer.com', id='customer host'
+    ),
+    pytest.param(
+        '"PJSIP_HEADER(add,X-CUSTOMER-ID)", value=0x7f001234 "9876543"',
+        '9876543',
+        id='customer-id header value',
+    ),
+    pytest.param(
+        'data=0x55 "add", value=0x66 "789012"', '789012', id='header add value'
+    ),
+    pytest.param('foo value=0x55 "1234567" bar', '1234567', id='bare numeric value'),
+    pytest.param('callerid=0x7f0012 "+33612345678"', '+33612345678', id='callerid arg'),
+    pytest.param('From: "John Smith" <sip:...>', 'John Smith', id='sip display name'),
+    pytest.param('channel PJSIP/ABcD1234@ctx active', 'ABcD1234', id='pjsip endpoint'),
+    pytest.param('PJSIP/ABcD1234-0000abcd hung up', 'ABcD1234', id='pjsip channel'),
+    pytest.param(
+        'Local/ABcD1234@default-0001', 'ABcD1234', id='local channel endpoint'
+    ),
+    pytest.param(
+        'pjsip/options/ABcD1234-00000040', 'ABcD1234', id='taskprocessor endpoint'
+    ),
+    pytest.param('dial_mobile,join,ABcD1234', 'ABcD1234', id='dial_mobile endpoint'),
+    pytest.param(
+        'stasis/p:mwi:all/1001@ctx-ID3-internal-aa-bb',
+        '1001@ctx',
+        id='mwi subscription',
+    ),
+    pytest.param('in ctx-ID42-internal', 'ctx-ID42', id='context tenant id'),
+    pytest.param('wazo-app-ab12cd34-ef56 started', 'ab12cd34', id='wazo app uuid'),
+    pytest.param('wazo-dial-mobile-ab12cd34-ef56', 'ab12cd34', id='wazo dial mobile'),
+    pytest.param('grp-ID5-ab12cd34-ef56', 'ab12cd34', id='group id'),
+    pytest.param(
+        'bridge 12345678-1234-1234-1234-123456789abc',
+        '12345678-1234-1234-1234-123456789abc',
+        id='bridge uuid',
+    ),
+    pytest.param(
+        'contact sip:user123@1.2.3.4:5060;ob', 'user123', id='sip contact uri'
+    ),
+    pytest.param('peer 8.8.8.8 reachable', '8.8.8.8', id='public ip'),
+]
+
+
+@pytest.mark.parametrize('line,forbidden', REDACTION_CASES)
+def test_pattern_redacts_sensitive_token(line, forbidden):
+    assert forbidden not in anonymize_line(line)
+
+
+def test_private_ip_is_preserved():
+    line = 'internal peer 10.42.0.1 and 192.168.1.5'
+    result = anonymize_line(line)
+    assert '10.42.0.1' in result
+    assert '192.168.1.5' in result
+
+
+def test_loopback_ip_is_preserved():
+    assert '127.0.0.1' in anonymize_line('bound to 127.0.0.1:5060')

--- a/sanitize-coredump/test_sanitize_coredump.py
+++ b/sanitize-coredump/test_sanitize_coredump.py
@@ -147,6 +147,15 @@ def test_ipv6_rule_does_not_corrupt_cpp_symbols_or_timestamps():
     assert anonymize_line('reload at 11:20:54 done') == 'reload at 11:20:54 done'
 
 
+def test_letter_only_ipv6_with_enough_groups_is_redacted():
+    # a 2-group letter-only match (cafe::babe) is kept as a likely ns::Sym false
+    # positive, but a longer letter-only match is structurally implausible as a
+    # C++ symbol and is a real address leak if left alone.
+    out = anonymize_line('peer dead:beef:cafe::face reachable')
+    assert 'dead:beef:cafe::face' not in out
+    assert 'IP_' in out
+
+
 def test_sip_contact_with_ipv6_collapses_to_single_token():
     out = anonymize_line('c sip:user42@[2606:4700::1111]:5060;ob done')
     assert 'user42' not in out  # user redacted, not just the address

--- a/sanitize-coredump/test_sanitize_coredump.py
+++ b/sanitize-coredump/test_sanitize_coredump.py
@@ -51,6 +51,11 @@ REDACTION_CASES = [
     pytest.param('channel PJSIP/ABcD1234@ctx active', 'ABcD1234', id='pjsip endpoint'),
     pytest.param('PJSIP/ABcD1234-0000abcd hung up', 'ABcD1234', id='pjsip channel'),
     pytest.param(
+        'dialstring PJSIP/ysy7AakU&PJSIP/other',
+        'ysy7AakU',
+        id='pjsip endpoint before &',
+    ),
+    pytest.param(
         'Local/ABcD1234@default-0001', 'ABcD1234', id='local channel endpoint'
     ),
     pytest.param(
@@ -132,7 +137,7 @@ def test_distinct_values_get_distinct_tokens():
 
 def test_sanitization_does_not_rematch_generated_tokens():
     line = (
-        'PJSIP/ABcD1234-0000abcd dial_mobile,join,EfGh5678 '
+        'PJSIP/ABcD1234-0000abcd&PJSIP/ZyXw9876 dial_mobile,join,EfGh5678 '
         'sip:user123@1.2.3.4:5060 12345678-1234-1234-1234-123456789abc '
         'ctx-ID42 wazo-app-ab12cd34-ef56 +33612345678'
     )

--- a/sanitize-coredump/test_sanitize_coredump.py
+++ b/sanitize-coredump/test_sanitize_coredump.py
@@ -118,6 +118,11 @@ def test_trunk_name_fully_redacted():
     assert '1a2b3c4d' not in out
 
 
+def test_trunk_rule_does_not_mangle_non_id_names():
+    # a config-like name (no uuid id) must be left intact, not half-eaten
+    assert anonymize_line('default_trunk_config') == 'default_trunk_config'
+
+
 # --- pseudonymization mechanics ---
 
 

--- a/sanitize-coredump/test_sanitize_coredump.py
+++ b/sanitize-coredump/test_sanitize_coredump.py
@@ -69,6 +69,11 @@ REDACTION_CASES = [
         id='mwi subscription',
     ),
     pytest.param('in ctx-ID42-internal', 'ctx-ID42', id='context tenant id'),
+    pytest.param(
+        'ctx-CABINETOPH-internal-3b554589-908c up',
+        'CABINETOPH',
+        id='context business name',
+    ),
     pytest.param('wazo-app-ab12cd34-ef56 started', 'ab12cd34', id='wazo app uuid'),
     pytest.param('wazo-dial-mobile-ab12cd34-ef56', 'ab12cd34', id='wazo dial mobile'),
     pytest.param('grp-ID5-ab12cd34-ef56', 'ab12cd34', id='group id'),
@@ -186,6 +191,30 @@ def test_trunk_name_fully_redacted():
     assert '1a2b3c4d' not in out
 
 
+def test_underscored_endpoint_names_are_redacted():
+    # business/customer names appear as endpoint names in several contexts
+    assert 'ALLIANZ' not in anonymize_line(
+        'pjsip/options/ALLIANZ_ANNE_BAILLET_UNYC-0000f868   23949   0'
+    )
+    assert 'BOULANGERIE' not in anonymize_line(
+        'pjsip/outreg/BOULANGERIE_GERARD_UNYC-00000228 x'
+    )
+    assert 'CABINET' not in anonymize_line(
+        'stasis/p:endpoint:PJSIP/CABINET_ANTUNEZ_UNYC-00008105 y'
+    )
+    assert 'ACS_INTERIM' not in anonymize_line(
+        'chan PJSIP/ACS_INTERIM_UNYC-0000abcd up'
+    )
+
+
+def test_underscored_endpoint_correlates_across_contexts():
+    sanitizer = Sanitizer()
+    a = sanitizer.line('pjsip/options/FEE_PAPILLON_UNYC-0000f868')
+    b = sanitizer.line('stasis/p:endpoint:PJSIP/FEE_PAPILLON_UNYC-00008105')
+    assert 'ENDPOINT_1' in a and 'ENDPOINT_1' in b  # same endpoint, same token
+    assert 'FEE_PAPILLON' not in a + b
+
+
 def test_human_named_trunk_is_redacted():
     # real trunk ids are not always hex UUIDs; some carry person/business names
     out = anonymize_line('PJSIP/dstny_trunk_Adil_Aube-0000021c answered')
@@ -216,7 +245,8 @@ def test_sanitization_does_not_rematch_generated_tokens():
     line = (
         'PJSIP/ABcD1234-0000abcd&PJSIP/ZyXw9876 dial_mobile,join,EfGh5678 '
         'sip:user123@1.2.3.4:5060 12345678-1234-1234-1234-123456789abc '
-        'ctx-ID42 wazo-app-ab12cd34-ef56 +33612345678'
+        'ctx-ID42 wazo-app-ab12cd34-ef56 +33612345678 '
+        'pjsip/options/ACS_INTERIM_UNYC-00008107 PJSIP/FEE_PAPILLON_UNYC-0000abcd'
     )
     once = Sanitizer().line(line)
     twice = Sanitizer().line(once)

--- a/sanitize-coredump/test_sanitize_coredump.py
+++ b/sanitize-coredump/test_sanitize_coredump.py
@@ -1,4 +1,4 @@
-"""Tests proving each redaction pattern in sanitize-coredump.py actually fires.
+"""Tests for the sanitize-coredump sanitizer.
 
 For a sanitizer the cardinal failure is the false negative (a leak), so every
 pattern gets a case asserting the sensitive token does not survive in the
@@ -6,6 +6,7 @@ output. The module filename has a dash, so it is loaded via importlib.
 """
 
 import importlib.util
+import json
 from pathlib import Path
 
 import pytest
@@ -15,10 +16,15 @@ _spec = importlib.util.spec_from_file_location('sanitize_coredump', _MODULE_PATH
 assert _spec is not None and _spec.loader is not None
 _module = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_module)
+
 anonymize_line = _module.anonymize_line
+Sanitizer = _module.Sanitizer
+main = _module.main
 
 
-# pytest.param(input line, substring that MUST NOT survive, id=pattern name)
+# pytest.param(input line, substring that MUST NOT survive, id=pattern name).
+# Customer-specific literals (brand/domain) are covered separately, since they
+# are config-driven and not part of the default structural ruleset.
 REDACTION_CASES = [
     pytest.param('caller +33612345678 dialed', '+33612345678', id='phone E164'),
     pytest.param(
@@ -26,16 +32,10 @@ REDACTION_CASES = [
         '0612345678',
         id='phone national',
         marks=pytest.mark.xfail(
-            reason='PHONE_NATIONAL is FR-specific; needs per-country handling '
-            '(see GENERALIZATION-PLAN.md)',
+            reason='national numbers need per-country config (phone_country); '
+            'not redacted by default (see README design notes)',
             strict=True,
         ),
-    ),
-    pytest.param(
-        'endpoint=customer_trunk_ab12cd34-ef', 'customer_trunk', id='customer trunk'
-    ),
-    pytest.param(
-        'host instance1.voip2.customer.com up', 'customer.com', id='customer host'
     ),
     pytest.param(
         '"PJSIP_HEADER(add,X-CUSTOMER-ID)", value=0x7f001234 "9876543"',
@@ -84,11 +84,100 @@ def test_pattern_redacts_sensitive_token(line, forbidden):
 
 
 def test_private_ip_is_preserved():
-    line = 'internal peer 10.42.0.1 and 192.168.1.5'
-    result = anonymize_line(line)
+    result = anonymize_line('internal peer 10.42.0.1 and 192.168.1.5')
     assert '10.42.0.1' in result
     assert '192.168.1.5' in result
 
 
 def test_loopback_ip_is_preserved():
     assert '127.0.0.1' in anonymize_line('bound to 127.0.0.1:5060')
+
+
+# --- pseudonymization mechanics ---
+
+
+def test_same_value_gets_same_token_across_lines():
+    sanitizer = Sanitizer()
+    first = sanitizer.line('answered PJSIP/ABcD1234-0000aaaa')
+    second = sanitizer.line('hangup PJSIP/ABcD1234-0000bbbb')
+    assert 'ENDPOINT_1' in first
+    assert 'ENDPOINT_1' in second
+
+
+def test_distinct_values_get_distinct_tokens():
+    out = Sanitizer().line('PJSIP/AAAAAA11@x and PJSIP/BBBBBB22@y')
+    assert 'ENDPOINT_1' in out
+    assert 'ENDPOINT_2' in out
+
+
+def test_sanitization_does_not_rematch_generated_tokens():
+    line = (
+        'PJSIP/ABcD1234-0000abcd dial_mobile,join,EfGh5678 '
+        'sip:user123@1.2.3.4:5060 12345678-1234-1234-1234-123456789abc '
+        'ctx-ID42 wazo-app-ab12cd34-ef56 +33612345678'
+    )
+    once = Sanitizer().line(line)
+    twice = Sanitizer().line(once)
+    assert once == twice
+
+
+def test_mapping_recovers_original_value():
+    sanitizer = Sanitizer()
+    sanitizer.line('channel PJSIP/ABcD1234@ctx')
+    assert sanitizer.pseudo.mapping()['ENDPOINT_1'] == 'ABcD1234'
+
+
+# --- caller-supplied config literals ---
+
+
+def test_config_literal_is_redacted():
+    out = Sanitizer(literals=('customer',)).line('endpoint=customer_trunk_ab12cd34-ef')
+    assert 'customer' not in out
+
+
+def test_config_domain_is_redacted():
+    out = Sanitizer(domains=('instance1.voip2.customer.com',)).line(
+        'host instance1.voip2.customer.com up'
+    )
+    assert 'customer.com' not in out
+
+
+def test_config_header_value_is_redacted():
+    out = Sanitizer(headers=('X-TENANT-NAME',)).line(
+        '"PJSIP_HEADER(add,X-TENANT-NAME)", value=0x7f001234 "AcmeCorp"'
+    )
+    assert 'AcmeCorp' not in out
+
+
+def test_national_phone_redacted_when_country_configured():
+    out = Sanitizer(phone_country='FR').line('from 0612345678 here')
+    assert '0612345678' not in out
+
+
+# --- CLI ---
+
+
+def test_cli_filter_sanitizes(tmp_path, capsys):
+    src = tmp_path / 'in.txt'
+    src.write_text('peer 8.8.8.8 reachable\n')
+    main(['--structural-only', 'filter', str(src)])
+    out = capsys.readouterr().out
+    assert '8.8.8.8' not in out
+    assert 'IP_1' in out
+
+
+def test_cli_warns_without_config(tmp_path, capsys):
+    src = tmp_path / 'in.txt'
+    src.write_text('nothing sensitive\n')
+    main(['filter', str(src)])
+    assert 'WARNING' in capsys.readouterr().err
+
+
+def test_cli_mapping_out_kept_out_of_sanitized_output(tmp_path, capsys):
+    src = tmp_path / 'in.txt'
+    src.write_text('peer 8.8.8.8 reachable\n')
+    mapping_path = tmp_path / 'map.json'
+    main(['--structural-only', '--mapping-out', str(mapping_path), 'filter', str(src)])
+    out = capsys.readouterr().out
+    assert '8.8.8.8' not in out
+    assert '8.8.8.8' in json.loads(mapping_path.read_text()).values()


### PR DESCRIPTION
- **feat: add sanitize-coredump incident template**
- **feat(sanitize-coredump): bug fix and tests**
- **feat(sanitize-coredump): generalize into config-driven sanitizer**
- **fix(sanitize-coredump): close leaks found verifying on real coredump**
- **fix(sanitize-coredump): tokenize PJSIP endpoints before any non-word char**
- **refactor(sanitize-coredump): require >=8 hex in trunk id to avoid mangling**
- **fix(sanitize-coredump): redact public IPv6 addresses**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The tool is meant to prevent customer data leaks; incorrect or silent regex rules could still publish PII, though the test suite and config warning mitigate that. De-anonymization keys are isolated to `--mapping-out`, so mishandling that file is the main operational risk.
> 
> **Overview**
> Adds a new **`sanitize-coredump`** Python CLI for scrubbing `ast_coredumper` output and Asterisk logs before public/upstream sharing. It replaces the old incident-specific report builder with a **config-driven** tool: always-on structural rules for Wazo/Asterisk PII (phones, public IPs/IPv6, SIP contacts, endpoints, trunks, UUIDs, tenant contexts, etc.) plus JSON **`--config`** literals (domains with gdb-truncation matching, custom headers, optional `phone_country`, extra regexes).
> 
> Sensitive values become **stable counter tokens** (`ENDPOINT_1`, …) for cross-thread correlation; the reverse map goes only to **`--mapping-out`**. Subcommands cover **`filter`** (stdin/files), **`thread`** (LWP backtraces), **`log`** (marker window), and **`summary`** (sanitized `info.txt` excerpt). Running without customer literals emits a stderr **warning** unless **`--structural-only`** is set.
> 
> **`test_sanitize_coredump.py`** parametrizes “must not leak” cases per pattern, plus idempotency, IPv6/C++ symbol safety, trunk/underscored endpoint rules, and CLI behavior. **`README.md`** documents usage; **`GENERALIZATION-PLAN.md`** records design rationale and open items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f5f424e5838c9d998f694b5c79c10e6d0834433. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->